### PR TITLE
feat(planning/dofa): Sprint 2 — DOFA Estrategias FO/DO/FA/DA completo

### DIFF
--- a/feature/planning/api/dofa.ts
+++ b/feature/planning/api/dofa.ts
@@ -33,7 +33,7 @@ export interface UpdateBscPerspectiveCommand {
 }
 
 // ---------------------------------------------------------------------------
-// Strategies
+// Strategy Types
 // ---------------------------------------------------------------------------
 
 export interface StrategyTypeDto {
@@ -41,6 +41,13 @@ export interface StrategyTypeDto {
   code: string;
   name: string;
 }
+
+/** Alias used by strategy-types-helpers.ts */
+export type StrategyType = StrategyTypeDto;
+
+// ---------------------------------------------------------------------------
+// Strategies
+// ---------------------------------------------------------------------------
 
 export interface StrategyDto {
   id: string;
@@ -51,6 +58,11 @@ export interface StrategyDto {
   status: string;
   progressPercentage: number;
   responsibleId?: string | null;
+  version?: number;
+  createdOnUtc?: string | null;
+  createdBy?: string | null;
+  lastModifiedOnUtc?: string | null;
+  lastModifiedBy?: string | null;
 }
 
 export interface CreateStrategyCommand {
@@ -59,6 +71,7 @@ export interface CreateStrategyCommand {
   dofaAnalysisId: string;
   strategicTypeId: string;
   responsibleId?: string | null;
+  // NOTE: do NOT send `status` — backend ignores it (PM-05)
 }
 
 export interface UpdateStrategyCommand {
@@ -66,6 +79,14 @@ export interface UpdateStrategyCommand {
   title: string;
   description?: string | null;
   responsibleId?: string | null;
+  // NOTE: do NOT send `status`, `dofaAnalysisId`, or `strategicTypeId` (PM-05)
+}
+
+export interface ListStrategiesFilters {
+  dofaAnalysisId?: string;
+  strategicType?: string;
+  status?: string;
+  responsibleId?: string;
 }
 
 export interface StrategyDofaItemLinkDto {
@@ -76,6 +97,34 @@ export interface StrategyDofaItemLinkDto {
   category?: string | null;
   description?: string | null;
   perspectiveName?: string | null;
+}
+
+export interface LinkStrategyDofaItemCommand {
+  dofaItemId: string;
+  contributionPercentage: number;
+}
+
+export interface UpdateStrategyDofaItemLinkCommand {
+  contributionPercentage: number;
+}
+
+export interface LinkStrategyObjectiveCommand {
+  objectiveId: string;
+  description?: string | null;
+}
+
+export interface UpdateStrategyObjectiveLinkCommand {
+  description?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Objective Statuses (catalogue)
+// ---------------------------------------------------------------------------
+
+export interface ObjectiveStatusDto {
+  id: string;
+  code: string;
+  name: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -109,6 +158,11 @@ export interface UpdateObjectiveCommand {
   name: string;
   description?: string | null;
   responsibleId?: string | null;
+}
+
+export interface ListObjectivesFilters {
+  status?: string;
+  responsibleId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -610,14 +664,39 @@ export async function listStrategyTypes(): Promise<StrategyTypeDto[]> {
 }
 
 // ---------------------------------------------------------------------------
+// Objective Statuses (catalogue)
+// ---------------------------------------------------------------------------
+
+const OBJECTIVE_STATUSES_BASE = "/api/v1/qualitas/strategic/objective-statuses";
+
+export async function listObjectiveStatuses(): Promise<ObjectiveStatusDto[]> {
+  try {
+    const { data } = await api.get<unknown>(OBJECTIVE_STATUSES_BASE);
+    return extractArray<ObjectiveStatusDto>(data);
+  } catch (error: unknown) {
+    if ((error as { __sessionExpired?: boolean })?.__sessionExpired) return [];
+    console.error("Error fetching objective statuses:", error);
+    toast.error(
+      (error as { response?: { data?: { message?: string } } })?.response?.data
+        ?.message || "Error al cargar los estados de objetivos",
+    );
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Strategies
 // ---------------------------------------------------------------------------
 
 const STRATEGIES_BASE = "/api/v1/qualitas/strategic/strategies";
 
-export async function listStrategies(): Promise<StrategyDto[]> {
+export async function listStrategies(
+  filters?: ListStrategiesFilters,
+): Promise<StrategyDto[]> {
   try {
-    const { data } = await api.get<unknown>(STRATEGIES_BASE);
+    const { data } = await api.get<unknown>(STRATEGIES_BASE, {
+      params: filters,
+    });
     return extractArray<StrategyDto>(data);
   } catch (error: unknown) {
     if ((error as { __sessionExpired?: boolean })?.__sessionExpired) return [];
@@ -627,6 +706,23 @@ export async function listStrategies(): Promise<StrategyDto[]> {
         ?.message || "Error al cargar las estrategias",
     );
     return [];
+  }
+}
+
+export async function getStrategyById(
+  strategyId: string,
+): Promise<StrategyDto | null> {
+  try {
+    const { data } = await api.get<StrategyDto>(`${STRATEGIES_BASE}/${strategyId}`);
+    return data ?? null;
+  } catch (error: unknown) {
+    if ((error as { __sessionExpired?: boolean })?.__sessionExpired) return null;
+    console.error("Error fetching strategy:", error);
+    toast.error(
+      (error as { response?: { data?: { message?: string } } })?.response?.data
+        ?.message || "Error al cargar la estrategia",
+    );
+    return null;
   }
 }
 
@@ -701,9 +797,14 @@ export async function listStrategyDofaItems(
 export async function linkDofaItemToStrategy(
   strategyId: string,
   dofaItemId: string,
+  payload?: LinkStrategyDofaItemCommand,
 ): Promise<boolean> {
+  const body: LinkStrategyDofaItemCommand = payload ?? {
+    dofaItemId,
+    contributionPercentage: 100,
+  };
   try {
-    await api.post(`${STRATEGIES_BASE}/${strategyId}/dofa-items/${dofaItemId}`);
+    await api.post(`${STRATEGIES_BASE}/${strategyId}/dofa-items/${dofaItemId}`, body);
     toast.success("Factor DOFA vinculado");
     return true;
   } catch (error: unknown) {
@@ -712,6 +813,26 @@ export async function linkDofaItemToStrategy(
     toast.error(
       (error as { response?: { data?: { message?: string } } })?.response?.data
         ?.message || "Error al vincular el factor DOFA",
+    );
+    return false;
+  }
+}
+
+export async function updateStrategyDofaItemLink(
+  strategyId: string,
+  linkId: string,
+  payload: UpdateStrategyDofaItemLinkCommand,
+): Promise<boolean> {
+  try {
+    await api.put(`${STRATEGIES_BASE}/${strategyId}/dofa-items/${linkId}`, payload);
+    toast.success("Vínculo de factor actualizado");
+    return true;
+  } catch (error: unknown) {
+    if ((error as { __sessionExpired?: boolean })?.__sessionExpired) return false;
+    console.error("Error updating strategy DOFA item link:", error);
+    toast.error(
+      (error as { response?: { data?: { message?: string } } })?.response?.data
+        ?.message || "Error al actualizar el vínculo de factor DOFA",
     );
     return false;
   }
@@ -752,9 +873,14 @@ export async function listStrategyObjectives(strategyId: string): Promise<Object
 export async function linkObjectiveToStrategy(
   strategyId: string,
   objectiveId: string,
+  payload?: LinkStrategyObjectiveCommand,
 ): Promise<boolean> {
+  const body: LinkStrategyObjectiveCommand = payload ?? {
+    objectiveId,
+    description: null,
+  };
   try {
-    await api.post(`${STRATEGIES_BASE}/${strategyId}/objectives/${objectiveId}`);
+    await api.post(`${STRATEGIES_BASE}/${strategyId}/objectives/${objectiveId}`, body);
     toast.success("Objetivo vinculado");
     return true;
   } catch (error: unknown) {
@@ -763,6 +889,26 @@ export async function linkObjectiveToStrategy(
     toast.error(
       (error as { response?: { data?: { message?: string } } })?.response?.data
         ?.message || "Error al vincular el objetivo",
+    );
+    return false;
+  }
+}
+
+export async function updateStrategyObjectiveLink(
+  strategyId: string,
+  linkId: string,
+  payload: UpdateStrategyObjectiveLinkCommand,
+): Promise<boolean> {
+  try {
+    await api.put(`${STRATEGIES_BASE}/${strategyId}/objectives/${linkId}`, payload);
+    toast.success("Vínculo de objetivo actualizado");
+    return true;
+  } catch (error: unknown) {
+    if ((error as { __sessionExpired?: boolean })?.__sessionExpired) return false;
+    console.error("Error updating strategy objective link:", error);
+    toast.error(
+      (error as { response?: { data?: { message?: string } } })?.response?.data
+        ?.message || "Error al actualizar el vínculo de objetivo",
     );
     return false;
   }
@@ -793,9 +939,13 @@ export async function unlinkObjectiveFromStrategy(
 
 const OBJECTIVES_BASE = "/api/v1/qualitas/strategic/objectives";
 
-export async function listObjectives(): Promise<ObjectiveDto[]> {
+export async function listObjectives(
+  filters?: ListObjectivesFilters,
+): Promise<ObjectiveDto[]> {
   try {
-    const { data } = await api.get<unknown>(OBJECTIVES_BASE);
+    const { data } = await api.get<unknown>(OBJECTIVES_BASE, {
+      params: filters,
+    });
     return extractArray<ObjectiveDto>(data);
   } catch (error: unknown) {
     if ((error as { __sessionExpired?: boolean })?.__sessionExpired) return [];

--- a/feature/planning/components/dofa/dofa-detail.tsx
+++ b/feature/planning/components/dofa/dofa-detail.tsx
@@ -6,13 +6,18 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
-import type { DofaItemDto } from "@/feature/planning/api/dofa";
+import type { DofaItemDto, StrategyDto, StrategyTypeDto } from "@/feature/planning/api/dofa";
 import {
   useDofaAnalysisQuery,
   useBscPerspectivesQuery,
+  useStrategiesQuery,
+  useStrategyTypesQuery,
 } from "@/feature/planning/hooks/use-dofa";
 import { DofaDiagnostico } from "./dofa-diagnostico";
 import { DofaSettingsSheet } from "./dofa-settings-sheet";
+import { EstrategiaList } from "./estrategia-list";
+import { StrategyPanel } from "./strategy-panel";
+import { mapStrategicTypeIdToCode, STRATEGY_CODES } from "./strategy-types-helpers";
 
 // ---------------------------------------------------------------------------
 // Types & constants
@@ -84,7 +89,8 @@ const PHASES: PhaseConfig[] = [
 function usePhaseProgress(
   analysisId: string,
   items: DofaItemDto[],
-  status: string | null | undefined,
+  strategies: StrategyDto[] | undefined,
+  strategyTypes: StrategyTypeDto[] | undefined,
 ) {
   const { data: bscPerspectives = [] } = useBscPerspectivesQuery();
 
@@ -116,8 +122,18 @@ function usePhaseProgress(
         ? 0
         : Math.round((filledPerspectives / perspectiveKeys.length) * 100);
 
-    // Phase 2 & 3: placeholder (Sprint 2/3)
-    const phase2Progress = 0;
+    // Phase 2: % of the 4 cross-types (FO/DO/FA/DA) that have ≥1 strategy in this analysis
+    const filteredStrategies = (strategies ?? []).filter(
+      (s) => s.dofaAnalysisId === analysisId,
+    );
+    const codesPresent = new Set(
+      filteredStrategies
+        .map((s) => mapStrategicTypeIdToCode(s.strategicTypeId, strategyTypes ?? []))
+        .filter((c): c is (typeof STRATEGY_CODES)[number] => c !== null),
+    );
+    const phase2Progress = Math.round((codesPresent.size / 4) * 100);
+
+    // Phase 3: placeholder (Sprint 3)
     const phase3Progress = 0;
 
     return {
@@ -127,14 +143,14 @@ function usePhaseProgress(
       },
       2: {
         progress: phase2Progress,
-        subtext: "0 estrategias · 0 objetivos",
+        subtext: `${filteredStrategies.length} ${filteredStrategies.length === 1 ? "estrategia" : "estrategias"} · ${codesPresent.size}/4 tipos`,
       },
       3: {
         progress: phase3Progress,
         subtext: "0 iniciados · 0 objetivos",
       },
     } as Record<Phase, { progress: number; subtext: string }>;
-  }, [items, bscPerspectives, analysisId]);
+  }, [items, bscPerspectives, analysisId, strategies, strategyTypes]);
 }
 
 // ---------------------------------------------------------------------------
@@ -150,10 +166,14 @@ export function DofaDetail({ analysisId, onBack }: Props) {
   const analysisQuery = useDofaAnalysisQuery(analysisId);
   const [activePhase, setActivePhase] = useState<Phase>(1);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [selectedStrategyId, setSelectedStrategyId] = useState<string | null>(null);
+
+  const { data: strategies } = useStrategiesQuery(analysisId);
+  const { data: strategyTypes } = useStrategyTypesQuery();
 
   const analysis = analysisQuery.data;
   const items = analysis?.items ?? [];
-  const phaseData = usePhaseProgress(analysisId, items, analysis?.status);
+  const phaseData = usePhaseProgress(analysisId, items, strategies, strategyTypes);
 
   const isReadOnly = analysis?.status === "approved" || analysis?.status === "archived";
 
@@ -313,9 +333,19 @@ export function DofaDetail({ analysisId, onBack }: Props) {
           <DofaDiagnostico analysisId={analysisId} readOnly={isReadOnly} />
         )}
         {activePhase === 2 && (
-          <div className="p-10 text-center text-sm text-muted-foreground">
-            Fase 2 — Estrategias (próximamente en Sprint 2)
-          </div>
+          <>
+            <EstrategiaList
+              analysisId={analysisId}
+              onSelectStrategy={(id) => setSelectedStrategyId(id)}
+              readOnly={isReadOnly}
+            />
+            <StrategyPanel
+              strategyId={selectedStrategyId}
+              analysisId={analysisId}
+              onClose={() => setSelectedStrategyId(null)}
+              readOnly={isReadOnly}
+            />
+          </>
         )}
         {activePhase === 3 && (
           <div className="p-10 text-center text-sm text-muted-foreground">

--- a/feature/planning/components/dofa/estrategia-list.tsx
+++ b/feature/planning/components/dofa/estrategia-list.tsx
@@ -1,0 +1,431 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import { useQueries } from "@tanstack/react-query";
+import { ChevronRight, Plus, X, User, Target, Layers } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import {
+  strategyKeys,
+  useStrategiesQuery,
+  useStrategyTypesQuery,
+  useStrategyCreateMutation,
+} from "@/feature/planning/hooks/use-dofa";
+import {
+  listStrategyDofaItems,
+  listStrategyObjectives,
+  type StrategyDto,
+} from "@/feature/planning/api/dofa";
+import {
+  STRATEGY_CODES,
+  STRATEGY_TYPE_CONFIG,
+  mapStrategicTypeIdToCode,
+  mapCodeToStrategicTypeId,
+  type StrategyCode,
+} from "./strategy-types-helpers";
+
+// ---------------------------------------------------------------------------
+// Tone → Tailwind classes
+// No risk-low / risk-medium custom tokens in this project — use Tailwind core.
+// ---------------------------------------------------------------------------
+const TONE_CLASSES: Record<
+  "low" | "medium" | "high" | "primary",
+  { borderLeft: string; bg: string; text: string; badge: string }
+> = {
+  low: {
+    borderLeft: "border-l-4 border-l-emerald-500",
+    bg: "bg-emerald-50/50",
+    text: "text-emerald-600",
+    badge: "bg-emerald-100 text-emerald-700 border-emerald-200",
+  },
+  medium: {
+    borderLeft: "border-l-4 border-l-amber-500",
+    bg: "bg-amber-50/50",
+    text: "text-amber-600",
+    badge: "bg-amber-100 text-amber-700 border-amber-200",
+  },
+  high: {
+    borderLeft: "border-l-4 border-l-rose-500",
+    bg: "bg-rose-50/50",
+    text: "text-rose-600",
+    badge: "bg-rose-100 text-rose-700 border-rose-200",
+  },
+  primary: {
+    borderLeft: "border-l-4 border-l-sky-500",
+    bg: "bg-sky-50/50",
+    text: "text-sky-600",
+    badge: "bg-sky-100 text-sky-700 border-sky-200",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+interface EstrategiaListProps {
+  analysisId: string;
+  onSelectStrategy: (strategyId: string) => void;
+  readOnly?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// StrategyCard — compact clickable row for a single strategy
+// PM-05: no status badge — backend does not support status updates
+// ---------------------------------------------------------------------------
+interface StrategyCardProps {
+  strategy: StrategyDto;
+  objCount: number;
+  factCount: number;
+  onSelect: (id: string) => void;
+  disabled?: boolean;
+}
+
+function StrategyCard({ strategy, objCount, factCount, onSelect, disabled }: StrategyCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(strategy.id)}
+      disabled={disabled}
+      className="w-full flex items-start gap-3 px-4 py-2.5 text-left hover:bg-accent/60 transition-colors cursor-pointer disabled:cursor-default disabled:opacity-70"
+    >
+      <span className="flex-1 min-w-0 text-sm text-foreground truncate leading-snug pt-0.5">
+        {strategy.title}
+      </span>
+      <div className="flex items-center gap-1.5 shrink-0">
+        {/* Responsable */}
+        <span className="inline-flex items-center gap-0.5 text-[10px] text-muted-foreground">
+          <User className="h-3 w-3" />
+          {strategy.responsibleId ? strategy.responsibleId.slice(0, 8) : "Sin asignar"}
+        </span>
+        {/* Count factores */}
+        <span className="inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[10px] bg-muted text-muted-foreground">
+          <Layers className="h-3 w-3" />
+          {factCount}
+        </span>
+        {/* Count objetivos */}
+        <span className="inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[10px] bg-muted text-muted-foreground">
+          <Target className="h-3 w-3" />
+          {objCount}
+        </span>
+      </div>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// InlineCreateInput — text field at the bottom of each group
+// ---------------------------------------------------------------------------
+interface InlineCreateInputProps {
+  code: StrategyCode;
+  onCommit: (code: StrategyCode, title: string) => void;
+  onCancel: () => void;
+  isPending?: boolean;
+}
+
+function InlineCreateInput({ code, onCommit, onCancel, isPending }: InlineCreateInputProps) {
+  const [draft, setDraft] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div className="border-t bg-muted/20 px-4 py-3 flex items-center gap-2">
+      <Input
+        ref={inputRef}
+        autoFocus
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && draft.trim()) onCommit(code, draft.trim());
+          if (e.key === "Escape") onCancel();
+        }}
+        placeholder={`Describe la estrategia ${code}...`}
+        className="h-8 text-sm"
+        disabled={isPending}
+      />
+      <Button
+        size="sm"
+        className="h-8 shrink-0"
+        onClick={() => draft.trim() && onCommit(code, draft.trim())}
+        disabled={!draft.trim() || isPending}
+      >
+        Agregar
+      </Button>
+      <Button
+        size="icon"
+        variant="ghost"
+        className="h-8 w-8 shrink-0"
+        onClick={onCancel}
+        disabled={isPending}
+      >
+        <X className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// StrategyGroupAccordion — one per DOFA cross-type
+// ---------------------------------------------------------------------------
+interface StrategyGroupAccordionProps {
+  code: StrategyCode;
+  strategies: StrategyDto[];
+  dofaItemCounts: Record<string, number>;
+  objectiveCounts: Record<string, number>;
+  onSelectStrategy: (id: string) => void;
+  readOnly: boolean;
+  creatingFor: StrategyCode | null;
+  onStartCreating: (code: StrategyCode) => void;
+  onCommitCreate: (code: StrategyCode, title: string) => void;
+  onCancelCreate: () => void;
+  isPending: boolean;
+}
+
+function StrategyGroupAccordion({
+  code,
+  strategies,
+  dofaItemCounts,
+  objectiveCounts,
+  onSelectStrategy,
+  readOnly,
+  creatingFor,
+  onStartCreating,
+  onCommitCreate,
+  onCancelCreate,
+  isPending,
+}: StrategyGroupAccordionProps) {
+  const [isOpen, setIsOpen] = useState(true);
+  const config = STRATEGY_TYPE_CONFIG[code];
+  const tone = TONE_CLASSES[config.tone];
+  const isCreating = creatingFor === code;
+  const { Icon, tagline } = config;
+
+  return (
+    <div className={cn("rounded-lg border bg-card overflow-hidden shadow-sm", tone.borderLeft)}>
+      {/* Group header */}
+      <div
+        className={cn(
+          "flex items-center gap-3 px-4 py-3 cursor-pointer select-none transition-colors",
+          tone.bg,
+          "hover:brightness-95",
+        )}
+        onClick={() => setIsOpen((o) => !o)}
+      >
+        <ChevronRight
+          className={cn(
+            "h-4 w-4 shrink-0 transition-transform text-muted-foreground",
+            isOpen && "rotate-90",
+          )}
+        />
+        <Icon className={cn("h-4 w-4 shrink-0", tone.text)} aria-hidden />
+        <span className={cn("font-semibold text-sm", tone.text)}>{code}</span>
+        <span className="text-sm text-foreground">— {tagline}</span>
+        <Badge variant="outline" className={cn("text-[10px] font-semibold ml-1", tone.badge)}>
+          {strategies.length}
+        </Badge>
+
+        {!readOnly && (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 px-2 text-xs ml-auto"
+            onClick={(e) => {
+              e.stopPropagation();
+              setIsOpen(true);
+              onStartCreating(code);
+            }}
+          >
+            <Plus className="h-3.5 w-3.5 mr-1" />
+            Nueva
+          </Button>
+        )}
+      </div>
+
+      {/* Group body */}
+      {isOpen && (
+        <div className="border-t bg-card">
+          {strategies.length === 0 && !isCreating ? (
+            <div className="px-4 py-6 text-center text-xs text-muted-foreground">
+              No hay estrategias{" "}
+              <span className={cn("font-semibold", tone.text)}>{code}</span> aún.
+              {!readOnly && (
+                <Button
+                  variant="link"
+                  size="sm"
+                  className="h-auto p-0 ml-1 text-xs"
+                  onClick={() => onStartCreating(code)}
+                >
+                  Crear la primera
+                </Button>
+              )}
+            </div>
+          ) : (
+            <ul className="divide-y">
+              {strategies.map((s) => (
+                <li key={s.id}>
+                  <StrategyCard
+                    strategy={s}
+                    objCount={objectiveCounts[s.id] ?? 0}
+                    factCount={dofaItemCounts[s.id] ?? 0}
+                    onSelect={onSelectStrategy}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {isCreating && !readOnly && (
+            <InlineCreateInput
+              code={code}
+              onCommit={onCommitCreate}
+              onCancel={onCancelCreate}
+              isPending={isPending}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// EstrategiaList — main export
+// ---------------------------------------------------------------------------
+export function EstrategiaList({ analysisId, onSelectStrategy, readOnly = false }: EstrategiaListProps) {
+  const { data: strategies = [], isLoading: loadingStrategies } = useStrategiesQuery(analysisId);
+  const { data: strategyTypes = [], isLoading: loadingTypes } = useStrategyTypesQuery();
+  const createMutation = useStrategyCreateMutation();
+
+  // -------------------------------------------------------------------------
+  // N+1 mitigation: batch queries for dofa-item and objective counts.
+  // useQueries issues one query per strategy but TanStack Query deduplicates
+  // and caches individually — far better than waterfall inside each card.
+  // staleTime=60s keeps counts fresh without hammering the API on every render.
+  // -------------------------------------------------------------------------
+  const dofaItemQueries = useQueries({
+    queries: strategies.map((s) => ({
+      queryKey: strategyKeys.dofaItems(s.id),
+      queryFn: () => listStrategyDofaItems(s.id),
+      staleTime: 60_000,
+    })),
+  });
+
+  const objectiveQueries = useQueries({
+    queries: strategies.map((s) => ({
+      queryKey: strategyKeys.objectives(s.id),
+      queryFn: () => listStrategyObjectives(s.id),
+      staleTime: 60_000,
+    })),
+  });
+
+  // Collapse query arrays into id→count maps
+  const dofaItemCounts = useMemo<Record<string, number>>(() => {
+    const map: Record<string, number> = {};
+    strategies.forEach((s, i) => {
+      map[s.id] = dofaItemQueries[i]?.data?.length ?? 0;
+    });
+    return map;
+  }, [strategies, dofaItemQueries]);
+
+  const objectiveCounts = useMemo<Record<string, number>>(() => {
+    const map: Record<string, number> = {};
+    strategies.forEach((s, i) => {
+      map[s.id] = objectiveQueries[i]?.data?.length ?? 0;
+    });
+    return map;
+  }, [strategies, objectiveQueries]);
+
+  // -------------------------------------------------------------------------
+  // R-1: Group strategies by strategicTypeId → code via catalog
+  // Orphan bucket: strategies whose typeId doesn't resolve are console.warn'd
+  // only — no fifth group rendered.
+  // -------------------------------------------------------------------------
+  const grouped = useMemo<Record<StrategyCode, StrategyDto[]>>(() => {
+    const map: Record<StrategyCode, StrategyDto[]> = { FO: [], DO: [], FA: [], DA: [] };
+    for (const s of strategies) {
+      const code = mapStrategicTypeIdToCode(s.strategicTypeId, strategyTypes);
+      if (code) {
+        map[code].push(s);
+      } else {
+        console.warn(
+          `[EstrategiaList] strategicTypeId "${s.strategicTypeId}" no resuelve en el catálogo. Estrategia "${s.title}" omitida del grid.`,
+        );
+      }
+    }
+    return map;
+  }, [strategies, strategyTypes]);
+
+  // Header counts
+  const totalStrategies = strategies.length;
+  const completedTypes = STRATEGY_CODES.filter((c) => grouped[c].length > 0).length;
+
+  // Inline-create state (global, one at a time)
+  const [creatingFor, setCreatingFor] = useState<StrategyCode | null>(null);
+
+  const handleStartCreating = (code: StrategyCode) => setCreatingFor(code);
+  const handleCancelCreate = () => setCreatingFor(null);
+
+  const handleCommitCreate = async (code: StrategyCode, title: string) => {
+    const strategicTypeId = mapCodeToStrategicTypeId(code, strategyTypes);
+    if (!strategicTypeId) {
+      console.warn(`[EstrategiaList] No se encontró strategicTypeId para code "${code}"`);
+      return;
+    }
+    await createMutation.mutateAsync({
+      title,
+      dofaAnalysisId: analysisId,
+      strategicTypeId,
+      description: null,
+      responsibleId: null,
+      // NOTE: do NOT send status (PM-05)
+    });
+    setCreatingFor(null);
+  };
+
+  if (loadingStrategies || loadingTypes) {
+    return (
+      <div className="p-4 space-y-3">
+        <Skeleton className="h-5 w-64" />
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+          <Skeleton className="h-28 w-full" />
+          <Skeleton className="h-28 w-full" />
+          <Skeleton className="h-28 w-full" />
+          <Skeleton className="h-28 w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      {/* Header summary */}
+      <p className="text-sm text-muted-foreground">
+        <span className="font-semibold text-foreground">{totalStrategies}</span>{" "}
+        {totalStrategies === 1 ? "estrategia definida" : "estrategias definidas"}
+        {" · "}
+        <span className="font-semibold text-foreground">{completedTypes}/4</span> tipos de cruce
+        completados
+      </p>
+
+      {/* 2×2 responsive grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+        {STRATEGY_CODES.map((code) => (
+          <StrategyGroupAccordion
+            key={code}
+            code={code}
+            strategies={grouped[code]}
+            dofaItemCounts={dofaItemCounts}
+            objectiveCounts={objectiveCounts}
+            onSelectStrategy={onSelectStrategy}
+            readOnly={readOnly}
+            creatingFor={creatingFor}
+            onStartCreating={handleStartCreating}
+            onCommitCreate={handleCommitCreate}
+            onCancelCreate={handleCancelCreate}
+            isPending={createMutation.isPending}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/feature/planning/components/dofa/strategy-create-objective-form.tsx
+++ b/feature/planning/components/dofa/strategy-create-objective-form.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  useObjectiveStatusesQuery,
+  useObjectiveCreateMutation,
+  useLinkObjectiveToStrategyMutation,
+} from "@/feature/planning/hooks/use-dofa";
+
+interface StrategyCreateObjectiveFormProps {
+  strategyId: string;
+  onDone: () => void;
+}
+
+export function StrategyCreateObjectiveForm({ strategyId, onDone }: StrategyCreateObjectiveFormProps) {
+  const createMutation = useObjectiveCreateMutation();
+  const linkMutation = useLinkObjectiveToStrategyMutation();
+  const { data: statuses = [] } = useObjectiveStatusesQuery();
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  // Use first available status as default (catalog-driven)
+  const defaultStatusId = statuses[0]?.id ?? "";
+
+  const handleSubmit = async () => {
+    if (!name.trim() || !defaultStatusId) return;
+    setSaving(true);
+    try {
+      // Step 1: create objective
+      // startDate/endDate default to today / +1yr — Sprint 3 will add date pickers
+      const today = new Date().toISOString().slice(0, 10);
+      const nextYear = `${new Date().getFullYear() + 1}-${today.slice(5)}`;
+      const newObj = await createMutation.mutateAsync({
+        name: name.trim(),
+        description: description.trim() || null,
+        statusId: defaultStatusId,
+        startDate: today,
+        endDate: nextYear,
+        responsibleId: null,
+        strategyId,
+      });
+      // Step 2: link to strategy — awaits Step 1 to avoid race condition
+      if (newObj?.id) {
+        await linkMutation.mutateAsync({
+          strategyId,
+          objectiveId: newObj.id,
+          payload: { objectiveId: newObj.id, description: null },
+        });
+      }
+      onDone();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="rounded-md border bg-muted/20 p-4 space-y-3">
+      <p className="text-xs font-medium text-foreground">Nuevo objetivo estratégico</p>
+      <div className="space-y-1.5">
+        <Label htmlFor="new-obj-name" className="text-xs">
+          Nombre <span className="text-destructive">*</span>
+        </Label>
+        <Input
+          id="new-obj-name"
+          autoFocus
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) handleSubmit();
+            if (e.key === "Escape") onDone();
+          }}
+          placeholder="Describe el objetivo en términos medibles..."
+          className="h-8 text-sm"
+          disabled={saving}
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="new-obj-desc" className="text-xs">
+          Descripción
+        </Label>
+        <Textarea
+          id="new-obj-desc"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={2}
+          className="text-sm resize-none"
+          disabled={saving}
+        />
+      </div>
+      <div className="flex items-center justify-end gap-2">
+        <Button variant="ghost" size="sm" className="h-8" onClick={onDone} disabled={saving}>
+          Cancelar
+        </Button>
+        <Button
+          size="sm"
+          className="h-8"
+          onClick={handleSubmit}
+          disabled={!name.trim() || !defaultStatusId || saving}
+        >
+          {saving ? "Guardando..." : "Crear y vincular"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/feature/planning/components/dofa/strategy-link-objective-dialog.tsx
+++ b/feature/planning/components/dofa/strategy-link-objective-dialog.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Link2, Search, Target } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  useObjectivesQuery,
+  useLinkObjectiveToStrategyMutation,
+} from "@/feature/planning/hooks/use-dofa";
+
+interface StrategyLinkObjectiveDialogProps {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  strategyId: string;
+  excludeIds: Set<string>;
+}
+
+export function StrategyLinkObjectiveDialog({
+  open,
+  onOpenChange,
+  strategyId,
+  excludeIds,
+}: StrategyLinkObjectiveDialogProps) {
+  const { data: allObjectives = [] } = useObjectivesQuery();
+  const linkMutation = useLinkObjectiveToStrategyMutation();
+  const [search, setSearch] = useState("");
+
+  const available = useMemo(
+    () =>
+      allObjectives.filter((o) => {
+        if (excludeIds.has(o.id)) return false;
+        if (!search.trim()) return true;
+        return o.name.toLowerCase().includes(search.toLowerCase());
+      }),
+    [allObjectives, excludeIds, search],
+  );
+
+  const handlePick = async (objectiveId: string) => {
+    await linkMutation.mutateAsync({
+      strategyId,
+      objectiveId,
+      payload: { objectiveId, description: null },
+    });
+    onOpenChange(false);
+    setSearch("");
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) setSearch("");
+        onOpenChange(v);
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-sm">
+            <Link2 className="h-4 w-4 text-primary" />
+            Vincular objetivo existente
+          </DialogTitle>
+          <DialogDescription>
+            Selecciona un objetivo del catálogo para vincularlo a esta estrategia.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+          <Input
+            autoFocus
+            placeholder="Buscar objetivo..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-8 h-9 text-sm"
+          />
+        </div>
+        <ScrollArea className="max-h-60 -mx-1 px-1">
+          {available.length === 0 ? (
+            <p className="py-6 text-center text-xs text-muted-foreground">
+              No hay objetivos disponibles para vincular.
+            </p>
+          ) : (
+            <ul className="space-y-1">
+              {available.map((o) => (
+                <li key={o.id}>
+                  <Button
+                    variant="ghost"
+                    className="w-full justify-start gap-2 h-auto py-2 font-normal text-left"
+                    onClick={() => handlePick(o.id)}
+                    disabled={linkMutation.isPending}
+                  >
+                    <Target className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                    <span className="flex-1 leading-snug text-sm text-foreground">{o.name}</span>
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/feature/planning/components/dofa/strategy-panel.tsx
+++ b/feature/planning/components/dofa/strategy-panel.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useState } from "react";
+import { Trash2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { cn } from "@/lib/utils";
+import {
+  useStrategyByIdQuery,
+  useStrategyTypesQuery,
+  useStrategyDeleteMutation,
+} from "@/feature/planning/hooks/use-dofa";
+import {
+  mapStrategicTypeIdToCode,
+  STRATEGY_TYPE_CONFIG,
+} from "./strategy-types-helpers";
+import { StrategyTabDescription } from "./strategy-tab-description";
+import { StrategyTabFactors } from "./strategy-tab-factors";
+import { StrategyTabObjectives } from "./strategy-tab-objectives";
+
+// ---------------------------------------------------------------------------
+// Tone badge classes (no risk-* tokens — Tailwind core)
+// ---------------------------------------------------------------------------
+const TONE_BADGE: Record<"low" | "medium" | "high" | "primary", string> = {
+  low: "bg-emerald-100 text-emerald-700 border-emerald-200",
+  medium: "bg-amber-100 text-amber-700 border-amber-200",
+  high: "bg-rose-100 text-rose-700 border-rose-200",
+  primary: "bg-sky-100 text-sky-700 border-sky-200",
+};
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+interface StrategyPanelProps {
+  strategyId: string | null;
+  analysisId: string;
+  onClose: () => void;
+  readOnly?: boolean;
+}
+
+export function StrategyPanel({
+  strategyId,
+  analysisId,
+  onClose,
+  readOnly = false,
+}: StrategyPanelProps) {
+  const { data: strategy, isLoading } = useStrategyByIdQuery(strategyId ?? undefined);
+  const { data: strategyTypes = [] } = useStrategyTypesQuery();
+  const deleteMutation = useStrategyDeleteMutation();
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  // Resolve type code for downstream tabs
+  const typeCode = strategy
+    ? mapStrategicTypeIdToCode(strategy.strategicTypeId, strategyTypes)
+    : null;
+  const typeConfig = typeCode ? STRATEGY_TYPE_CONFIG[typeCode] : null;
+
+  const handleDelete = async () => {
+    if (!strategyId) return;
+    await deleteMutation.mutateAsync(strategyId);
+    setDeleteOpen(false);
+    onClose();
+  };
+
+  return (
+    <Sheet open={!!strategyId} onOpenChange={(o) => !o && onClose()}>
+      <SheetContent className="sm:max-w-2xl overflow-y-auto flex flex-col gap-0 p-0">
+        {/* Header */}
+        <SheetHeader className="px-6 pt-6 pb-4 border-b">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex-1 min-w-0">
+              {isLoading ? (
+                <Skeleton className="h-6 w-48" />
+              ) : (
+                <SheetTitle className="text-base leading-snug">
+                  {strategy?.title ?? "Sin título"}
+                </SheetTitle>
+              )}
+            </div>
+          </div>
+          <SheetDescription asChild>
+            <div className="flex items-center gap-3 flex-wrap mt-1">
+              {typeConfig && typeCode && (
+                <Badge
+                  variant="outline"
+                  className={cn("text-xs font-semibold", TONE_BADGE[typeConfig.tone])}
+                >
+                  {typeCode} · {typeConfig.tagline}
+                </Badge>
+              )}
+              {/* Progress bar (R-6: read-only from backend) */}
+              {strategy && (
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <span className="shrink-0">Progreso</span>
+                  <div className="w-24 h-1.5 rounded-full bg-muted overflow-hidden">
+                    <div
+                      className="h-full rounded-full bg-emerald-500 transition-all"
+                      style={{ width: `${strategy.progressPercentage ?? 0}%` }}
+                    />
+                  </div>
+                  <span className="tabular-nums">{strategy.progressPercentage ?? 0}%</span>
+                </div>
+              )}
+            </div>
+          </SheetDescription>
+        </SheetHeader>
+
+        {/* Tabs */}
+        <Tabs defaultValue="description" className="flex-1 flex flex-col">
+          <TabsList className="grid grid-cols-3 mx-6 mt-4">
+            <TabsTrigger value="description">Descripción</TabsTrigger>
+            <TabsTrigger value="factors">Factores</TabsTrigger>
+            <TabsTrigger value="objectives">Objetivos</TabsTrigger>
+          </TabsList>
+
+          <div className="flex-1 px-6 py-4">
+            <TabsContent value="description" className="mt-0">
+              {strategy ? (
+                <StrategyTabDescription
+                  strategy={strategy}
+                  readOnly={readOnly}
+                />
+              ) : (
+                <div className="space-y-3">
+                  <Skeleton className="h-9 w-full" />
+                  <Skeleton className="h-20 w-full" />
+                </div>
+              )}
+            </TabsContent>
+
+            <TabsContent value="factors" className="mt-0">
+              {strategyId && (
+                <StrategyTabFactors
+                  strategyId={strategyId}
+                  analysisId={analysisId}
+                  readOnly={readOnly}
+                  strategyTypeCode={typeCode}
+                />
+              )}
+            </TabsContent>
+
+            <TabsContent value="objectives" className="mt-0">
+              {strategyId && (
+                <StrategyTabObjectives
+                  strategyId={strategyId}
+                  readOnly={readOnly}
+                />
+              )}
+            </TabsContent>
+          </div>
+        </Tabs>
+
+        {/* Footer: delete action */}
+        {!readOnly && strategyId && (
+          <div className="px-6 py-4 border-t flex justify-end">
+            <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+              <AlertDialogTrigger asChild>
+                <Button variant="ghost" size="sm" className="text-destructive hover:text-destructive hover:bg-destructive/10">
+                  <Trash2 className="h-4 w-4 mr-1.5" />
+                  Eliminar estrategia
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>¿Eliminar estrategia?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Esta acción no se puede deshacer. Los factores y objetivos vinculados perderán el vínculo.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={handleDelete}
+                    disabled={deleteMutation.isPending}
+                    className="bg-destructive text-white hover:bg-destructive/90"
+                  >
+                    {deleteMutation.isPending ? "Eliminando..." : "Eliminar"}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/feature/planning/components/dofa/strategy-tab-description.tsx
+++ b/feature/planning/components/dofa/strategy-tab-description.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState } from "react";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  useStrategyUpdateMutation,
+} from "@/feature/planning/hooks/use-dofa";
+import { useUserSearch } from "@/feature/user/hooks/useUserSearch";
+import type { StrategyDto } from "@/feature/planning/api/dofa";
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+interface StrategyTabDescriptionProps {
+  strategy: StrategyDto;
+  readOnly?: boolean;
+}
+
+export function StrategyTabDescription({ strategy, readOnly = false }: StrategyTabDescriptionProps) {
+  const updateMutation = useStrategyUpdateMutation();
+
+  // Local draft state — saved on blur
+  const [title, setTitle] = useState(strategy.title);
+  const [description, setDescription] = useState(strategy.description ?? "");
+  const [responsibleId, setResponsibleId] = useState<string>(
+    strategy.responsibleId ?? "__none__",
+  );
+
+  // Load users for responsible select (pageSize 100 covers most orgs)
+  const { data: usersPage } = useUserSearch({ pageSize: 100, search: "" });
+  const users = usersPage?.items ?? [];
+
+  const save = (overrides?: Partial<{ title: string; description: string; responsibleId: string | null }>) => {
+    const payload = {
+      id: strategy.id,
+      title: overrides?.title ?? title,
+      description: overrides?.description !== undefined ? overrides.description || null : description || null,
+      responsibleId:
+        overrides?.responsibleId !== undefined
+          ? overrides.responsibleId
+          : responsibleId === "__none__"
+          ? null
+          : responsibleId,
+      // NOTE: do NOT send status (PM-05)
+    };
+    updateMutation.mutate({ strategyId: strategy.id, payload });
+  };
+
+  const handleResponsibleChange = (value: string) => {
+    setResponsibleId(value);
+    save({ responsibleId: value === "__none__" ? null : value });
+  };
+
+  return (
+    <div className="space-y-5">
+      {/* Title */}
+      <div className="space-y-1.5">
+        <Label htmlFor="strat-title">Título</Label>
+        <Input
+          id="strat-title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          onBlur={() => title.trim() && save({ title: title.trim() })}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.currentTarget.blur();
+            }
+          }}
+          placeholder="Título de la estrategia"
+          disabled={readOnly}
+          className="text-sm"
+        />
+      </div>
+
+      {/* Description */}
+      <div className="space-y-1.5">
+        <Label htmlFor="strat-desc">Descripción</Label>
+        <Textarea
+          id="strat-desc"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          onBlur={() => save({ description })}
+          placeholder="Describe la estrategia en detalle..."
+          disabled={readOnly}
+          rows={4}
+          className="text-sm resize-none"
+        />
+      </div>
+
+      {/* Responsible */}
+      <div className="space-y-1.5">
+        <Label>Responsable</Label>
+        <Select
+          value={responsibleId}
+          onValueChange={handleResponsibleChange}
+          disabled={readOnly}
+        >
+          <SelectTrigger className="text-sm">
+            <SelectValue placeholder="Sin asignar" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__none__">Sin asignar</SelectItem>
+            {users.map((u) => (
+              <SelectItem key={u.id} value={u.id}>
+                {u.firstName} {u.lastName}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Progress (R-6: read-only from backend — do not recalculate) */}
+      <div className="space-y-1.5">
+        <Label>Progreso</Label>
+        <div className="space-y-1">
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>Avance general</span>
+            <span className="tabular-nums font-medium">{strategy.progressPercentage ?? 0}%</span>
+          </div>
+          <div className="w-full h-2 rounded-full bg-muted overflow-hidden">
+            <div
+              className="h-full rounded-full bg-emerald-500 transition-all"
+              style={{ width: `${strategy.progressPercentage ?? 0}%` }}
+            />
+          </div>
+          <p className="text-[11px] text-muted-foreground">
+            Calculado a partir de objetivos vinculados
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/feature/planning/components/dofa/strategy-tab-factors.tsx
+++ b/feature/planning/components/dofa/strategy-tab-factors.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Check, Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import {
+  useDofaAnalysisQuery,
+  useStrategyDofaItemsQuery,
+  useLinkDofaItemToStrategyMutation,
+  useUnlinkDofaItemFromStrategyMutation,
+} from "@/feature/planning/hooks/use-dofa";
+import {
+  STRATEGY_TYPE_CONFIG,
+  type StrategyCode,
+} from "./strategy-types-helpers";
+
+// ---------------------------------------------------------------------------
+// Category chip styling (Tailwind core — no risk-* tokens)
+// ---------------------------------------------------------------------------
+const CATEGORY_CLASSES: Record<string, { bg: string; text: string; border: string; letter: string }> = {
+  Fortaleza:    { bg: "bg-emerald-100", text: "text-emerald-700", border: "border-emerald-200", letter: "F" },
+  Oportunidad:  { bg: "bg-sky-100",     text: "text-sky-700",     border: "border-sky-200",     letter: "O" },
+  Debilidad:    { bg: "bg-rose-100",    text: "text-rose-700",    border: "border-rose-200",    letter: "D" },
+  Amenaza:      { bg: "bg-amber-100",   text: "text-amber-700",   border: "border-amber-200",   letter: "A" },
+};
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+interface StrategyTabFactorsProps {
+  strategyId: string;
+  analysisId: string;
+  readOnly?: boolean;
+  strategyTypeCode: StrategyCode | null;
+}
+
+export function StrategyTabFactors({
+  strategyId,
+  analysisId,
+  readOnly = false,
+  strategyTypeCode,
+}: StrategyTabFactorsProps) {
+  const [search, setSearch] = useState("");
+
+  const { data: analysis, isLoading: loadingAnalysis } = useDofaAnalysisQuery(analysisId);
+  const { data: linkedItems = [], isLoading: loadingLinks } = useStrategyDofaItemsQuery(strategyId);
+  const linkMutation = useLinkDofaItemToStrategyMutation();
+  const unlinkMutation = useUnlinkDofaItemFromStrategyMutation();
+
+  // R-1 R-5 defensiva: if code can't be resolved, show error state
+  if (!strategyTypeCode) {
+    return (
+      <p className="text-sm text-muted-foreground py-6 text-center">
+        No se puede determinar el tipo de cruce — contacte soporte.
+      </p>
+    );
+  }
+
+  const filterCategories = STRATEGY_TYPE_CONFIG[strategyTypeCode].filterCategories;
+
+  // All DOFA items from the analysis, filtered by relevant categories
+  const allItems = analysis?.items ?? [];
+  const relevantItems = useMemo(
+    () => allItems.filter((item) => filterCategories.includes(item.category) && item.isActive),
+    [allItems, filterCategories],
+  );
+
+  // Set of dofaItemIds that are currently linked
+  const linkedItemIdSet = useMemo(
+    () => new Set(linkedItems.map((l) => l.dofaItemId)),
+    [linkedItems],
+  );
+
+  // Map dofaItemId → link record id (needed for unlink)
+  const itemIdToLinkId = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const l of linkedItems) {
+      map[l.dofaItemId] = l.id;
+    }
+    return map;
+  }, [linkedItems]);
+
+  // Search filter
+  const filteredItems = useMemo(() => {
+    if (!search.trim()) return relevantItems;
+    const q = search.toLowerCase();
+    return relevantItems.filter(
+      (item) =>
+        item.description.toLowerCase().includes(q) ||
+        item.category.toLowerCase().includes(q),
+    );
+  }, [relevantItems, search]);
+
+  // Group by category
+  const grouped = useMemo(() => {
+    const map: Record<string, typeof filteredItems> = {};
+    for (const item of filteredItems) {
+      if (!map[item.category]) map[item.category] = [];
+      map[item.category].push(item);
+    }
+    return map;
+  }, [filteredItems]);
+
+  const handleToggle = async (dofaItemId: string) => {
+    if (readOnly) return;
+    if (linkedItemIdSet.has(dofaItemId)) {
+      const linkId = itemIdToLinkId[dofaItemId];
+      if (linkId) await unlinkMutation.mutateAsync({ strategyId, linkId });
+    } else {
+      // R-7: contributionPercentage default 100
+      await linkMutation.mutateAsync({
+        strategyId,
+        dofaItemId,
+        payload: { dofaItemId, contributionPercentage: 100 },
+      });
+    }
+  };
+
+  if (loadingAnalysis || loadingLinks) {
+    return (
+      <div className="space-y-2">
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    );
+  }
+
+  if (relevantItems.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed bg-muted/20 p-6 text-center text-xs text-muted-foreground">
+        Aún no hay factores en este análisis. Vuelve a la Fase 1 (Diagnóstico) para agregar factores de tipo{" "}
+        <span className="font-medium">{filterCategories.join(" / ")}</span>.
+      </div>
+    );
+  }
+
+  const linkedCount = linkedItems.filter((l) =>
+    relevantItems.some((item) => item.id === l.dofaItemId),
+  ).length;
+
+  return (
+    <div className="space-y-4">
+      {/* Counter + search */}
+      <div className="flex items-center gap-3">
+        <p className="text-xs text-muted-foreground flex-1">
+          <span className="font-medium text-foreground">{linkedCount}</span> vinculados de{" "}
+          <span className="font-medium text-foreground">{relevantItems.length}</span> disponibles
+        </p>
+        <div className="relative w-48">
+          <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+          <Input
+            placeholder="Buscar..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="h-8 text-xs pl-7"
+          />
+        </div>
+      </div>
+
+      {/* Grouped items by category */}
+      {filterCategories.map((category) => {
+        const items = grouped[category] ?? [];
+        if (items.length === 0) return null;
+        const cls = CATEGORY_CLASSES[category] ?? {
+          bg: "bg-muted",
+          text: "text-muted-foreground",
+          border: "border-border",
+          letter: category[0],
+        };
+
+        return (
+          <div key={category}>
+            <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wide mb-2">
+              {category}s
+            </p>
+            <div className="space-y-1.5">
+              {items.map((item) => {
+                const isLinked = linkedItemIdSet.has(item.id);
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    disabled={readOnly || linkMutation.isPending || unlinkMutation.isPending}
+                    onClick={() => handleToggle(item.id)}
+                    className={cn(
+                      "w-full flex items-start gap-2.5 rounded-md border px-3 py-2 text-left text-sm transition-colors",
+                      isLinked
+                        ? cn(cls.bg, cls.text, cls.border, "font-medium")
+                        : "bg-card text-muted-foreground border-border hover:border-primary/40 hover:text-foreground",
+                      (readOnly) && "cursor-not-allowed opacity-70",
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "mt-0.5 shrink-0 inline-flex items-center justify-center h-5 w-5 rounded text-[10px] font-bold border",
+                        isLinked ? "bg-white/60 border-current" : cn(cls.bg, cls.text, cls.border),
+                      )}
+                    >
+                      {isLinked ? <Check className="h-3 w-3" /> : cls.letter}
+                    </span>
+                    <span className="flex-1 leading-snug">{item.description}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/feature/planning/components/dofa/strategy-tab-objectives.tsx
+++ b/feature/planning/components/dofa/strategy-tab-objectives.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Link2, Plus, Target, X } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  useStrategyObjectivesQuery,
+  useObjectiveStatusesQuery,
+  useUnlinkObjectiveFromStrategyMutation,
+} from "@/feature/planning/hooks/use-dofa";
+import { StrategyLinkObjectiveDialog } from "./strategy-link-objective-dialog";
+import { StrategyCreateObjectiveForm } from "./strategy-create-objective-form";
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+interface StrategyTabObjectivesProps {
+  strategyId: string;
+  readOnly?: boolean;
+}
+
+export function StrategyTabObjectives({ strategyId, readOnly = false }: StrategyTabObjectivesProps) {
+  const { data: linkedObjectives = [], isLoading } = useStrategyObjectivesQuery(strategyId);
+  const { data: statuses = [] } = useObjectiveStatusesQuery();
+  const unlinkMutation = useUnlinkObjectiveFromStrategyMutation();
+  const [linkDialogOpen, setLinkDialogOpen] = useState(false);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+
+  // R-5: defensive status lookup — orphan statusId shows "Sin estado"
+  const statusName = (statusId: string) =>
+    statuses.find((s) => s.id === statusId)?.name ?? "Sin estado";
+
+  const linkedIds = useMemo(() => new Set(linkedObjectives.map((o) => o.id)), [linkedObjectives]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        <Skeleton className="h-14 w-full" />
+        <Skeleton className="h-14 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Linked objectives list */}
+      {linkedObjectives.length === 0 ? (
+        <div className="rounded-md border border-dashed bg-muted/20 p-6 text-center">
+          <Target className="h-8 w-8 mx-auto text-muted-foreground/50 mb-2" />
+          <p className="text-sm font-medium text-foreground">Sin objetivos vinculados</p>
+          <p className="text-xs text-muted-foreground mt-1">
+            Sin objetivos no puede medirse ni ejecutarse esta estrategia.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {linkedObjectives.map((obj) => (
+            <div
+              key={obj.id}
+              className="rounded-md border bg-card px-3 py-2.5 flex items-start gap-3"
+            >
+              <Target className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground" />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-foreground leading-snug">{obj.name}</p>
+                <div className="mt-1 flex items-center gap-2">
+                  <Badge variant="outline" className="text-[10px]">
+                    {statusName(obj.statusId)}
+                  </Badge>
+                  {/* R-6: progress is read-only from backend */}
+                  <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+                    <div className="w-16 h-1 rounded-full bg-muted overflow-hidden">
+                      <div
+                        className="h-full rounded-full bg-emerald-500"
+                        style={{ width: `${obj.progressPercentage ?? 0}%` }}
+                      />
+                    </div>
+                    <span className="tabular-nums">{obj.progressPercentage ?? 0}%</span>
+                  </div>
+                </div>
+              </div>
+              {!readOnly && (
+                <button
+                  type="button"
+                  onClick={() =>
+                    // linkId = objectiveId (backend path-based link, no separate link record exposed)
+                    unlinkMutation.mutate({ strategyId, linkId: obj.id })
+                  }
+                  className="shrink-0 text-muted-foreground hover:text-destructive transition-colors"
+                  title="Desvincular"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Inline create form */}
+      {showCreateForm && !readOnly && (
+        <StrategyCreateObjectiveForm
+          strategyId={strategyId}
+          onDone={() => setShowCreateForm(false)}
+        />
+      )}
+
+      {/* Action buttons */}
+      {!readOnly && !showCreateForm && (
+        <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 text-xs"
+            onClick={() => setShowCreateForm(true)}
+          >
+            <Plus className="h-3.5 w-3.5 mr-1.5" />
+            Crear objetivo
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-8 text-xs"
+            onClick={() => setLinkDialogOpen(true)}
+          >
+            <Link2 className="h-3.5 w-3.5 mr-1.5" />
+            Vincular existente
+          </Button>
+        </div>
+      )}
+
+      {/* Link existing dialog */}
+      <StrategyLinkObjectiveDialog
+        open={linkDialogOpen}
+        onOpenChange={setLinkDialogOpen}
+        strategyId={strategyId}
+        excludeIds={linkedIds}
+      />
+    </div>
+  );
+}

--- a/feature/planning/components/dofa/strategy-types-helpers.ts
+++ b/feature/planning/components/dofa/strategy-types-helpers.ts
@@ -1,0 +1,66 @@
+import { TrendingUp, ShieldCheck, ArrowUpRight, ShieldAlert, type LucideIcon } from "lucide-react";
+import type { StrategyType } from "@/feature/planning/api/dofa";
+
+export const STRATEGY_CODES = ["FO", "DO", "FA", "DA"] as const;
+export type StrategyCode = (typeof STRATEGY_CODES)[number];
+
+export const STRATEGY_TYPE_CONFIG: Record<
+  StrategyCode,
+  {
+    tagline: string;
+    tone: "low" | "medium" | "high" | "primary";
+    Icon: LucideIcon;
+    filterCategories: readonly string[];
+  }
+> = {
+  FO: {
+    tagline: "Potenciar",
+    tone: "low",
+    Icon: TrendingUp,
+    filterCategories: ["Fortaleza", "Oportunidad"],
+  },
+  FA: {
+    tagline: "Defender",
+    tone: "medium",
+    Icon: ShieldCheck,
+    filterCategories: ["Fortaleza", "Amenaza"],
+  },
+  DO: {
+    tagline: "Mejorar",
+    tone: "primary",
+    Icon: ArrowUpRight,
+    filterCategories: ["Debilidad", "Oportunidad"],
+  },
+  DA: {
+    tagline: "Sobrevivir",
+    tone: "high",
+    Icon: ShieldAlert,
+    filterCategories: ["Debilidad", "Amenaza"],
+  },
+};
+
+/**
+ * Given a strategicTypeId UUID and the catalog of StrategyTypeDto,
+ * returns the matching DOFA code ("FO" | "DO" | "FA" | "DA") or null.
+ */
+export function mapStrategicTypeIdToCode(
+  typeId: string,
+  catalog: StrategyType[],
+): StrategyCode | null {
+  const found = catalog.find((t) => t.id === typeId);
+  if (!found) return null;
+  const code = found.code as StrategyCode;
+  return STRATEGY_CODES.includes(code) ? code : null;
+}
+
+/**
+ * Given a DOFA code and the catalog of StrategyTypeDto,
+ * returns the matching strategicTypeId UUID or null.
+ */
+export function mapCodeToStrategicTypeId(
+  code: StrategyCode,
+  catalog: StrategyType[],
+): string | null {
+  const found = catalog.find((t) => t.code === code);
+  return found?.id ?? null;
+}

--- a/feature/planning/hooks/use-dofa.ts
+++ b/feature/planning/hooks/use-dofa.ts
@@ -15,15 +15,19 @@ import {
   updateBscPerspective,
   deleteBscPerspective,
   listStrategyTypes,
+  listObjectiveStatuses,
   listStrategies,
+  getStrategyById,
   createStrategy,
   updateStrategy,
   deleteStrategy,
   listStrategyDofaItems,
   linkDofaItemToStrategy,
+  updateStrategyDofaItemLink,
   unlinkDofaItemFromStrategy,
   listStrategyObjectives,
   linkObjectiveToStrategy,
+  updateStrategyObjectiveLink,
   unlinkObjectiveFromStrategy,
   listObjectives,
   createObjective,
@@ -51,6 +55,10 @@ import {
   type UpdateBscPerspectiveCommand,
   type CreateStrategyCommand,
   type UpdateStrategyCommand,
+  type LinkStrategyDofaItemCommand,
+  type UpdateStrategyDofaItemLinkCommand,
+  type LinkStrategyObjectiveCommand,
+  type UpdateStrategyObjectiveLinkCommand,
   type CreateObjectiveCommand,
   type UpdateObjectiveCommand,
   type CreateGoalCommand,
@@ -61,7 +69,13 @@ import {
   type UpdateMeasurementCommand,
   type CreateStakeholderDofaLinkCommand,
   type UpdateStakeholderDofaLinkCommand,
+  type ListStrategiesFilters,
+  type ListObjectivesFilters,
 } from "../api/dofa";
+
+// ---------------------------------------------------------------------------
+// Query key factories
+// ---------------------------------------------------------------------------
 
 export const dofaKeys = {
   all: ["strategic", "dofa"] as const,
@@ -82,10 +96,17 @@ export const strategyTypeKeys = {
   list: () => [...strategyTypeKeys.all, "list"] as const,
 };
 
+export const objectiveStatusKeys = {
+  all: ["strategic", "objective-statuses"] as const,
+  list: () => [...objectiveStatusKeys.all, "list"] as const,
+};
+
 export const strategyKeys = {
   all: ["strategic", "strategies"] as const,
   lists: () => [...strategyKeys.all, "list"] as const,
-  list: () => [...strategyKeys.lists()] as const,
+  /** Pass filters to distinguish cached queries per analysisId (or other filter). */
+  list: (filters?: { analysisId?: string }) =>
+    [...strategyKeys.lists(), filters ?? {}] as const,
   details: () => [...strategyKeys.all, "detail"] as const,
   detail: (id: string) => [...strategyKeys.details(), id] as const,
   dofaItems: (strategyId: string) =>
@@ -97,7 +118,8 @@ export const strategyKeys = {
 export const objectiveKeys = {
   all: ["strategic", "objectives"] as const,
   lists: () => [...objectiveKeys.all, "list"] as const,
-  list: () => [...objectiveKeys.lists()] as const,
+  list: (filters?: ListObjectivesFilters) =>
+    [...objectiveKeys.lists(), filters ?? {}] as const,
   details: () => [...objectiveKeys.all, "detail"] as const,
   detail: (id: string) => [...objectiveKeys.details(), id] as const,
 };
@@ -126,6 +148,10 @@ export const stakeholderDofaLinkKeys = {
   lists: () => [...stakeholderDofaLinkKeys.all, "list"] as const,
   list: () => [...stakeholderDofaLinkKeys.lists()] as const,
 };
+
+// ---------------------------------------------------------------------------
+// DOFA Analyses
+// ---------------------------------------------------------------------------
 
 export function useDofaAnalysesQuery() {
   return useQuery({
@@ -285,7 +311,7 @@ export function useBscPerspectiveDeleteMutation() {
 }
 
 // ---------------------------------------------------------------------------
-// Strategy Types
+// Strategy Types (catalogue)
 // ---------------------------------------------------------------------------
 
 export function useStrategyTypesQuery() {
@@ -293,11 +319,53 @@ export function useStrategyTypesQuery() {
 }
 
 // ---------------------------------------------------------------------------
+// Objective Statuses (catalogue)
+// ---------------------------------------------------------------------------
+
+export function useObjectiveStatusesQuery() {
+  return useQuery({
+    queryKey: objectiveStatusKeys.list(),
+    queryFn: listObjectiveStatuses,
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Strategies
 // ---------------------------------------------------------------------------
 
-export function useStrategiesQuery() {
-  return useQuery({ queryKey: strategyKeys.list(), queryFn: listStrategies });
+/**
+ * Fetch strategies, optionally scoped to an analysis.
+ *
+ * NOTE (PM-07): The backend ignores the `?dofaAnalysisId` query param as of
+ * the 2026-04-29 smoke test. We pass it anyway so it works automatically when
+ * Hernán fixes server-side filtering. In the meantime we filter client-side.
+ */
+export function useStrategiesQuery(analysisId?: string) {
+  const filters: ListStrategiesFilters | undefined = analysisId
+    ? { dofaAnalysisId: analysisId }
+    : undefined;
+  return useQuery({
+    queryKey: strategyKeys.list(analysisId ? { analysisId } : undefined),
+    queryFn: async () => {
+      const all = await listStrategies(filters);
+      // PM-07 workaround: filter client-side since backend ignores dofaAnalysisId
+      if (!analysisId) return all;
+      return all.filter((s) => s.dofaAnalysisId === analysisId);
+    },
+  });
+}
+
+export function useStrategyByIdQuery(strategyId?: string) {
+  return useQuery({
+    queryKey: strategyId
+      ? strategyKeys.detail(strategyId)
+      : strategyKeys.detail("__none__"),
+    queryFn: async () => {
+      if (!strategyId) return null;
+      return getStrategyById(strategyId);
+    },
+    enabled: !!strategyId,
+  });
 }
 
 export function useStrategyCreateMutation() {
@@ -320,8 +388,11 @@ export function useStrategyUpdateMutation() {
       strategyId: string;
       payload: UpdateStrategyCommand;
     }) => updateStrategy(strategyId, payload),
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: strategyKeys.all });
+      queryClient.invalidateQueries({
+        queryKey: strategyKeys.detail(variables.strategyId),
+      });
     },
   });
 }
@@ -335,6 +406,10 @@ export function useStrategyDeleteMutation() {
     },
   });
 }
+
+// ---------------------------------------------------------------------------
+// Strategy ↔ DOFA Item links
+// ---------------------------------------------------------------------------
 
 export function useStrategyDofaItemsQuery(strategyId: string) {
   return useQuery({
@@ -350,10 +425,32 @@ export function useLinkDofaItemToStrategyMutation() {
     mutationFn: ({
       strategyId,
       dofaItemId,
+      payload,
     }: {
       strategyId: string;
       dofaItemId: string;
-    }) => linkDofaItemToStrategy(strategyId, dofaItemId),
+      payload?: LinkStrategyDofaItemCommand;
+    }) => linkDofaItemToStrategy(strategyId, dofaItemId, payload),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: strategyKeys.dofaItems(variables.strategyId),
+      });
+    },
+  });
+}
+
+export function useUpdateStrategyDofaItemLinkMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      strategyId,
+      linkId,
+      payload,
+    }: {
+      strategyId: string;
+      linkId: string;
+      payload: UpdateStrategyDofaItemLinkCommand;
+    }) => updateStrategyDofaItemLink(strategyId, linkId, payload),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
         queryKey: strategyKeys.dofaItems(variables.strategyId),
@@ -380,6 +477,10 @@ export function useUnlinkDofaItemFromStrategyMutation() {
   });
 }
 
+// ---------------------------------------------------------------------------
+// Strategy ↔ Objective links
+// ---------------------------------------------------------------------------
+
 export function useStrategyObjectivesQuery(strategyId: string) {
   return useQuery({
     queryKey: strategyKeys.objectives(strategyId),
@@ -394,10 +495,33 @@ export function useLinkObjectiveToStrategyMutation() {
     mutationFn: ({
       strategyId,
       objectiveId,
+      payload,
     }: {
       strategyId: string;
       objectiveId: string;
-    }) => linkObjectiveToStrategy(strategyId, objectiveId),
+      payload?: LinkStrategyObjectiveCommand;
+    }) => linkObjectiveToStrategy(strategyId, objectiveId, payload),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: strategyKeys.objectives(variables.strategyId),
+      });
+      queryClient.invalidateQueries({ queryKey: objectiveKeys.all });
+    },
+  });
+}
+
+export function useUpdateStrategyObjectiveLinkMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      strategyId,
+      linkId,
+      payload,
+    }: {
+      strategyId: string;
+      linkId: string;
+      payload: UpdateStrategyObjectiveLinkCommand;
+    }) => updateStrategyObjectiveLink(strategyId, linkId, payload),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
         queryKey: strategyKeys.objectives(variables.strategyId),
@@ -428,8 +552,11 @@ export function useUnlinkObjectiveFromStrategyMutation() {
 // Objectives
 // ---------------------------------------------------------------------------
 
-export function useObjectivesQuery() {
-  return useQuery({ queryKey: objectiveKeys.list(), queryFn: listObjectives });
+export function useObjectivesQuery(filters?: ListObjectivesFilters) {
+  return useQuery({
+    queryKey: objectiveKeys.list(filters),
+    queryFn: () => listObjectives(filters),
+  });
 }
 
 export function useObjectiveCreateMutation() {


### PR DESCRIPTION
## Sprint 2 — DOFA Fase 2 (Estrategias) completo

  Migración del módulo de Estrategias DOFA desde Lovable v2 al productivo.

  ### Sub-sprints incluidos
  - **2.1** — API layer + hooks (`f91df2d`)
  - **2.2** — Grid 4 grupos FO/DO/FA/DA con accordion + input inline crear (`c6113ba`)
  - **2.3** — StrategyPanel side sheet con 3 tabs: Descripción / Factores / Objetivos (`b6820bf`)
  - **2.4** — Wiring final en dofa-detail.tsx con phase2Progress real (`a574f38`)

  ### Reconciliaciones aplicadas
  - R-1: cross_type string ↔ strategicTypeId UUID via STRATEGY_TYPE_CONFIG helpers
  - R-2: __sessionExpired silencioso en mutations
  - R-5: defensiva contra statusId orphan en objetivos
  - R-7: contributionPercentage default 100 al vincular factores

  ### Diferencias UI conscientes vs Lovable
  - Selector de status manual omitido (PM-05 — backend no acepta cambio de status)
  - Botón IA omitido (sin endpoint backend)

  ### Tech debt registrada
  - PM-05: backend no acepta status en UpdateStrategyCommand
  - PM-06: progressPercentage validar recálculo
  - PM-07: filtro ?dofaAnalysisId no implementado server-side
  - PM-08: sin reorden de strategies
  - PM-11.1: handler tira 500 en lugar de 409 al duplicar link
  - PM-12: BadImageFormatException en tenant provisioning (descubierto en logs hoy)

  ### Backend fixes incluidos (PR separados)
  - PM-11 v1: FK config StrategyObjectiveLink (`dfa6487` en QualitasNexus-develop)
  - PM-11 v2: AddCreatedOnUtcToStrategyObjectiveLink migration (`bb3cf0b3` en QualitasNexus-develop)

  Closes Sprint 2 of DOFA_Estrategias_v1.1 spec.