### PR TITLE
feat(planning/dofa): indicators and measurements tabs — Sprint 3.4

### DIFF
--- a/feature/planning/api/dofa.ts
+++ b/feature/planning/api/dofa.ts
@@ -118,14 +118,40 @@ export interface UpdateStrategyObjectiveLinkCommand {
 }
 
 // ---------------------------------------------------------------------------
+// Catalogue types (shared shape for all status/frequency/type catalogues)
+// ---------------------------------------------------------------------------
+
+export interface CatalogStatusDto {
+  id: string;
+  code: string;
+  name: string;
+  colorHex?: string;
+  displayOrder?: number;
+  isActive: boolean;
+}
+
+export interface IndicatorTypeDto extends CatalogStatusDto {
+  description?: string;
+}
+
+export interface GoalTrendDto extends CatalogStatusDto {
+  /** Unicode symbol: ↑ → ↓ */
+  symbol: string;
+}
+
+// ---------------------------------------------------------------------------
 // Objective Statuses (catalogue)
 // ---------------------------------------------------------------------------
 
+/** @deprecated Use CatalogStatusDto — kept for backwards-compat with Sprint 2 */
 export interface ObjectiveStatusDto {
   id: string;
   code: string;
   name: string;
 }
+
+/** Goal statuses catalogue (same dual-seed issue as objective-statuses — PM-13) */
+export type GoalStatusDto = CatalogStatusDto;
 
 // ---------------------------------------------------------------------------
 // Objectives
@@ -134,30 +160,45 @@ export interface ObjectiveStatusDto {
 export interface ObjectiveDto {
   id: string;
   name: string;
-  description?: string | null;
-  analysisId?: string | null;
+  description: string | null;
+  analysisId: string | null;
   statusId: string;
   startDate: string;
   endDate: string;
   progressPercentage: number;
-  responsibleId?: string | null;
+  responsibleId: string | null;
+  createdOnUtc: string;
+  createdBy: string | null;
+  lastModifiedOnUtc: string | null;
+  lastModifiedBy: string | null;
 }
 
 export interface CreateObjectiveCommand {
   name: string;
-  description?: string | null;
+  description: string | null;
   statusId: string;
   startDate: string;
   endDate: string;
-  responsibleId?: string | null;
-  strategyId?: string | null;
+  responsibleId: string | null;
+  /** Optional link to a DOFA analysis (PM-15: client-side filter by analysisId) */
+  analysisId: string | null;
+}
+
+/** Alias used by Sprint 3+ components */
+export type CreateObjectivePayload = CreateObjectiveCommand;
+
+export interface UpdateObjectivePayload {
+  id: string;
+  name: string;
+  description: string | null;
+  responsibleId: string | null;
 }
 
 export interface UpdateObjectiveCommand {
   id: string;
   name: string;
-  description?: string | null;
-  responsibleId?: string | null;
+  description: string | null;
+  responsibleId: string | null;
 }
 
 export interface ListObjectivesFilters {
@@ -176,13 +217,18 @@ export interface GoalDto {
   targetValue: number;
   currentValue: number;
   baselineValue: number;
-  unit?: string | null;
+  unit: string | null;
   weight: number;
   deadline: string;
   statusId: string;
-  responsibleId?: string | null;
+  responsibleId: string | null;
   progressPercentage: number;
+  createdOnUtc: string;
+  createdBy: string | null;
 }
+
+/** Alias used by Sprint 3+ components */
+export type CreateGoalPayload = CreateGoalCommand;
 
 export interface CreateGoalCommand {
   description: string;
@@ -190,11 +236,11 @@ export interface CreateGoalCommand {
   targetValue: number;
   currentValue: number;
   baselineValue: number;
-  unit?: string | null;
+  unit: string | null;
   weight: number;
   deadline: string;
   statusId: string;
-  responsibleId?: string | null;
+  responsibleId: string | null;
 }
 
 export interface UpdateGoalCommand {
@@ -203,77 +249,95 @@ export interface UpdateGoalCommand {
   targetValue: number;
   currentValue: number;
   baselineValue: number;
-  unit?: string | null;
+  unit: string | null;
   weight: number;
   deadline: string;
   statusId: string;
-  responsibleId?: string | null;
+  responsibleId: string | null;
 }
 
 // ---------------------------------------------------------------------------
 // Indicators (GoalIndicators)
 // ---------------------------------------------------------------------------
 
-/** Derived from CreateGoalIndicatorRequest shape — backend GET schema not in spec */
 export interface IndicatorDto {
   id: string;
   name: string;
   goalId: string;
-  formula?: string | null;
+  formula: string | null;
   frequencyId: string;
-  trendId?: string | null;
+  trendId: string | null;
   indicatorTypeId: string;
-  dataSource?: string | null;
-  responsibleId?: string | null;
+  dataSource: string | null;
+  responsibleId: string | null;
+  /** null in LIST responses; populated array in single GET (PM-14) */
+  measurements: MeasurementDto[] | null;
+  createdOnUtc: string;
+  createdBy: string | null;
+  lastModifiedOnUtc: string | null;
+  lastModifiedBy: string | null;
 }
 
 export interface CreateIndicatorCommand {
   name: string;
-  goalId: string;
-  formula?: string | null;
+  /** NOTE: do NOT include goalId here — it comes from the path param */
   frequencyId: string;
-  trendId?: string | null;
   indicatorTypeId: string;
-  dataSource?: string | null;
-  responsibleId?: string | null;
+  trendId: string | null;
+  formula: string | null;
+  dataSource: string | null;
+  responsibleId: string | null;
 }
+
+/** Alias used by Sprint 3+ components */
+export type CreateIndicatorPayload = CreateIndicatorCommand;
 
 export interface UpdateIndicatorCommand {
   name: string;
-  formula?: string | null;
+  formula: string | null;
   frequencyId: string;
-  trendId?: string | null;
+  trendId: string | null;
   indicatorTypeId: string;
-  dataSource?: string | null;
-  responsibleId?: string | null;
+  dataSource: string | null;
+  responsibleId: string | null;
 }
 
 // ---------------------------------------------------------------------------
 // Measurements
 // ---------------------------------------------------------------------------
 
-/** Backend has no GET list endpoint for measurements — create/update/delete only */
+/** Backend has no GET list endpoint for measurements (PM-14). Read via getIndicatorDetail. */
 export interface MeasurementDto {
   id: string;
   goalIndicatorId: string;
   measurementDate: string;
   value: number;
-  observations?: string | null;
-  evidenceUrl?: string | null;
+  observations: string | null;
+  evidenceUrl: string | null;
+  /** FK to user who recorded the measurement (PM-20: verify backend assigns from JWT) */
+  measuredBy: string | null;
+  createdOnUtc: string;
+  createdBy: string | null;
+  lastModifiedOnUtc: string | null;
+  lastModifiedBy: string | null;
 }
 
 export interface CreateMeasurementCommand {
-  goalIndicatorId: string;
-  measurementDate: string;
   value: number;
-  observations?: string | null;
-  evidenceUrl?: string | null;
+  measurementDate: string;
+  /** PM-19: redundant with path param indicatorId but required by backend */
+  goalIndicatorId: string;
+  observations: string | null;
+  evidenceUrl: string | null;
 }
+
+/** Alias used by Sprint 3+ components */
+export type CreateMeasurementPayload = CreateMeasurementCommand;
 
 export interface UpdateMeasurementCommand {
   value: number;
-  observations?: string | null;
-  evidenceUrl?: string | null;
+  observations: string | null;
+  evidenceUrl: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -684,6 +748,75 @@ export async function listObjectiveStatuses(): Promise<ObjectiveStatusDto[]> {
   }
 }
 
+const GOAL_STATUSES_BASE = "/api/v1/qualitas/strategic/goal-statuses";
+
+/** PM-13: returns 9 values with dual seed — prefer PascalCase codes (Defined/InProgress/…) */
+export async function listGoalStatuses(): Promise<GoalStatusDto[]> {
+  try {
+    const { data } = await api.get<unknown>(GOAL_STATUSES_BASE);
+    return extractArray<GoalStatusDto>(data);
+  } catch (error: unknown) {
+    if ((error as { __sessionExpired?: boolean })?.__sessionExpired) return [];
+    console.error("Error fetching goal statuses:", error);
+    toast.error(
+      (error as { response?: { data?: { message?: string } } })?.response?.data
+        ?.message || "Error al cargar los estados de metas",
+    );
+    return [];
+  }
+}
+
+const GOAL_FREQUENCIES_BASE = "/api/v1/qualitas/strategic/goal-frequencies";
+
+export async function listGoalFrequencies(): Promise<CatalogStatusDto[]> {
+  try {
+    const { data } = await api.get<unknown>(GOAL_FREQUENCIES_BASE);
+    return extractArray<CatalogStatusDto>(data);
+  } catch (error: unknown) {
+    if ((error as { __sessionExpired?: boolean })?.__sessionExpired) return [];
+    console.error("Error fetching goal frequencies:", error);
+    toast.error(
+      (error as { response?: { data?: { message?: string } } })?.response?.data
+        ?.message || "Error al cargar las frecuencias",
+    );
+    return [];
+  }
+}
+
+const GOAL_TRENDS_BASE = "/api/v1/qualitas/strategic/goal-trends";
+
+export async function listGoalTrends(): Promise<GoalTrendDto[]> {
+  try {
+    const { data } = await api.get<unknown>(GOAL_TRENDS_BASE);
+    return extractArray<GoalTrendDto>(data);
+  } catch (error: unknown) {
+    if ((error as { __sessionExpired?: boolean })?.__sessionExpired) return [];
+    console.error("Error fetching goal trends:", error);
+    toast.error(
+      (error as { response?: { data?: { message?: string } } })?.response?.data
+        ?.message || "Error al cargar las tendencias",
+    );
+    return [];
+  }
+}
+
+const INDICATOR_TYPES_BASE = "/api/v1/qualitas/strategic/indicator-types";
+
+export async function listIndicatorTypes(): Promise<IndicatorTypeDto[]> {
+  try {
+    const { data } = await api.get<unknown>(INDICATOR_TYPES_BASE);
+    return extractArray<IndicatorTypeDto>(data);
+  } catch (error: unknown) {
+    if ((error as { __sessionExpired?: boolean })?.__sessionExpired) return [];
+    console.error("Error fetching indicator types:", error);
+    toast.error(
+      (error as { response?: { data?: { message?: string } } })?.response?.data
+        ?.message || "Error al cargar los tipos de indicador",
+    );
+    return [];
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Strategies
 // ---------------------------------------------------------------------------
@@ -1011,6 +1144,21 @@ export async function deleteObjective(objectiveId: string): Promise<boolean> {
   }
 }
 
+export async function getObjective(objectiveId: string): Promise<ObjectiveDto | null> {
+  try {
+    const { data } = await api.get<ObjectiveDto>(`${OBJECTIVES_BASE}/${objectiveId}`);
+    return data ?? null;
+  } catch (error: unknown) {
+    if ((error as { __sessionExpired?: boolean })?.__sessionExpired) return null;
+    console.error("Error fetching objective:", error);
+    toast.error(
+      (error as { response?: { data?: { message?: string } } })?.response?.data
+        ?.message || "Error al cargar el objetivo",
+    );
+    return null;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Goals
 // ---------------------------------------------------------------------------
@@ -1067,6 +1215,37 @@ export async function updateGoal(
   }
 }
 
+export async function getGoal(goalId: string): Promise<GoalDto | null> {
+  try {
+    const { data } = await api.get<GoalDto>(`${GOALS_BASE}/${goalId}`);
+    return data ?? null;
+  } catch (error: unknown) {
+    if ((error as { __sessionExpired?: boolean })?.__sessionExpired) return null;
+    console.error("Error fetching goal:", error);
+    toast.error(
+      (error as { response?: { data?: { message?: string } } })?.response?.data
+        ?.message || "Error al cargar la meta",
+    );
+    return null;
+  }
+}
+
+export async function deleteGoal(goalId: string): Promise<boolean> {
+  try {
+    await api.delete(`${GOALS_BASE}/${goalId}`);
+    toast.success("Meta eliminada");
+    return true;
+  } catch (error: unknown) {
+    if ((error as { __sessionExpired?: boolean })?.__sessionExpired) return false;
+    console.error("Error deleting goal:", error);
+    toast.error(
+      (error as { response?: { data?: { message?: string } } })?.response?.data
+        ?.message || "Error al eliminar la meta",
+    );
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Indicators
 // ---------------------------------------------------------------------------
@@ -1088,14 +1267,40 @@ export async function listIndicators(goalId: string): Promise<IndicatorDto[]> {
   }
 }
 
+export async function getIndicatorDetail(
+  goalId: string,
+  indicatorId: string,
+): Promise<IndicatorDto | null> {
+  try {
+    const { data } = await api.get<IndicatorDto>(
+      `${GOALS_BASE}/${goalId}/indicators/${indicatorId}`,
+    );
+    return data ?? null;
+  } catch (error: unknown) {
+    if ((error as { __sessionExpired?: boolean })?.__sessionExpired) return null;
+    console.error("Error fetching indicator detail:", error);
+    toast.error(
+      (error as { response?: { data?: { message?: string } } })?.response?.data
+        ?.message || "Error al cargar el indicador",
+    );
+    return null;
+  }
+}
+
 export async function createIndicator(
   goalId: string,
   payload: CreateIndicatorCommand,
 ): Promise<IndicatorDto | null> {
   try {
-    const { data } = await api.post<IndicatorDto>(
+    // PM-17: POST returns UUID raw string, not an object
+    const { data: rawId } = await api.post<string>(
       `${GOALS_BASE}/${goalId}/indicators`,
       payload,
+    );
+    const newId = String(rawId).replace(/^"|"$/g, "");
+    // Fetch the full object (single GET includes measurements: [])
+    const { data } = await api.get<IndicatorDto>(
+      `${GOALS_BASE}/${goalId}/indicators/${newId}`,
     );
     toast.success("Indicador creado");
     return data ?? null;
@@ -1158,14 +1363,16 @@ const INDICATORS_BASE = "/api/v1/qualitas/strategic/indicators";
 export async function createMeasurement(
   indicatorId: string,
   payload: CreateMeasurementCommand,
-): Promise<MeasurementDto | null> {
+): Promise<string | null> {
   try {
-    const { data } = await api.post<MeasurementDto>(
+    // PM-17: POST returns UUID raw string, not a MeasurementDto
+    const { data: rawId } = await api.post<string>(
       `${INDICATORS_BASE}/${indicatorId}/measurements`,
       payload,
     );
+    const newId = String(rawId).replace(/^"|"$/g, "");
     toast.success("Medición registrada");
-    return data ?? null;
+    return newId;
   } catch (error: unknown) {
     if ((error as { __sessionExpired?: boolean })?.__sessionExpired) return null;
     console.error("Error creating measurement:", error);

--- a/feature/planning/components/dofa/create-objective-dialog.tsx
+++ b/feature/planning/components/dofa/create-objective-dialog.tsx
@@ -73,8 +73,8 @@ export function CreateObjectiveDialog({
       name: name.trim(),
       description: description.trim() || null,
       statusId: resolvedStatusId,
-      startDate,
-      endDate,
+      startDate: new Date(startDate + "T12:00:00").toISOString(),
+      endDate: new Date(endDate + "T12:00:00").toISOString(),
       responsibleId: null,
       analysisId,
     });

--- a/feature/planning/components/dofa/create-objective-dialog.tsx
+++ b/feature/planning/components/dofa/create-objective-dialog.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  useObjectiveCreateMutation,
+  useObjectiveStatusesQuery,
+} from "@/feature/planning/hooks/use-dofa";
+
+interface CreateObjectiveDialogProps {
+  open: boolean;
+  analysisId: string;
+  onClose: () => void;
+  onCreated: (objectiveId: string) => void;
+}
+
+export function CreateObjectiveDialog({
+  open,
+  analysisId,
+  onClose,
+  onCreated,
+}: CreateObjectiveDialogProps) {
+  const { data: statuses = [] } = useObjectiveStatusesQuery();
+  const createMutation = useObjectiveCreateMutation();
+
+  const today = new Date().toISOString().slice(0, 10);
+  const nextYear = `${new Date().getFullYear() + 1}${today.slice(4)}`;
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [statusId, setStatusId] = useState<string>("");
+  const [startDate, setStartDate] = useState(today);
+  const [endDate, setEndDate] = useState(nextYear);
+
+  // Resolve default statusId once the catalog loads (PM-13: prefer PascalCase "Planned" seed)
+  const resolvedStatusId =
+    statusId ||
+    statuses.find((s) => s.code === "Planned")?.id ||
+    statuses[0]?.id ||
+    "";
+
+  const isValid = name.trim() && resolvedStatusId && startDate && endDate;
+
+  const handleClose = () => {
+    setName("");
+    setDescription("");
+    setStatusId("");
+    setStartDate(today);
+    setEndDate(nextYear);
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    if (!isValid) return;
+    const result = await createMutation.mutateAsync({
+      name: name.trim(),
+      description: description.trim() || null,
+      statusId: resolvedStatusId,
+      startDate,
+      endDate,
+      responsibleId: null,
+      analysisId,
+    });
+    if (result?.id) {
+      handleClose();
+      onCreated(result.id);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) handleClose(); }}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Nuevo objetivo estratégico</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* Name */}
+          <div className="space-y-1.5">
+            <Label htmlFor="obj-name">
+              Nombre <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="obj-name"
+              autoFocus
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Describe el objetivo en términos medibles..."
+              disabled={createMutation.isPending}
+            />
+          </div>
+
+          {/* Description */}
+          <div className="space-y-1.5">
+            <Label htmlFor="obj-desc">Descripción</Label>
+            <Textarea
+              id="obj-desc"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={2}
+              className="resize-none text-sm"
+              disabled={createMutation.isPending}
+            />
+          </div>
+
+          {/* Status */}
+          <div className="space-y-1.5">
+            <Label>
+              Estado <span className="text-destructive">*</span>
+            </Label>
+            <Select
+              value={resolvedStatusId}
+              onValueChange={setStatusId}
+              disabled={createMutation.isPending || statuses.length === 0}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Selecciona un estado" />
+              </SelectTrigger>
+              <SelectContent>
+                {statuses.map((s) => (
+                  <SelectItem key={s.id} value={s.id}>
+                    {s.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Dates */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="obj-start">
+                Fecha inicio <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                id="obj-start"
+                type="date"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+                disabled={createMutation.isPending}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="obj-end">
+                Fecha fin <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                id="obj-end"
+                type="date"
+                value={endDate}
+                onChange={(e) => setEndDate(e.target.value)}
+                disabled={createMutation.isPending}
+              />
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose} disabled={createMutation.isPending}>
+            Cancelar
+          </Button>
+          <Button onClick={handleSubmit} disabled={!isValid || createMutation.isPending}>
+            {createMutation.isPending ? "Guardando..." : "Crear objetivo"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/feature/planning/components/dofa/dofa-detail.tsx
+++ b/feature/planning/components/dofa/dofa-detail.tsx
@@ -16,6 +16,7 @@ import {
 import { DofaDiagnostico } from "./dofa-diagnostico";
 import { DofaSettingsSheet } from "./dofa-settings-sheet";
 import { EstrategiaList } from "./estrategia-list";
+import { ObjectivePanel } from "./objective-panel";
 import { PlanGrid } from "./plan-grid";
 import { StrategyPanel } from "./strategy-panel";
 import { mapStrategicTypeIdToCode, STRATEGY_CODES } from "./strategy-types-helpers";
@@ -357,8 +358,11 @@ export function DofaDetail({ analysisId, onBack }: Props) {
               readOnly={isReadOnly}
               onSelectObjective={setSelectedObjectiveId}
             />
-            {/* Sprint 3.3: wire ObjectivePanel when selectedObjectiveId is set */}
-            {selectedObjectiveId && null}
+            <ObjectivePanel
+              objectiveId={selectedObjectiveId}
+              onClose={() => setSelectedObjectiveId(null)}
+              readOnly={isReadOnly}
+            />
           </>
         )}
       </div>

--- a/feature/planning/components/dofa/dofa-detail.tsx
+++ b/feature/planning/components/dofa/dofa-detail.tsx
@@ -16,6 +16,7 @@ import {
 import { DofaDiagnostico } from "./dofa-diagnostico";
 import { DofaSettingsSheet } from "./dofa-settings-sheet";
 import { EstrategiaList } from "./estrategia-list";
+import { PlanGrid } from "./plan-grid";
 import { StrategyPanel } from "./strategy-panel";
 import { mapStrategicTypeIdToCode, STRATEGY_CODES } from "./strategy-types-helpers";
 
@@ -167,6 +168,8 @@ export function DofaDetail({ analysisId, onBack }: Props) {
   const [activePhase, setActivePhase] = useState<Phase>(1);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [selectedStrategyId, setSelectedStrategyId] = useState<string | null>(null);
+  // Sprint 3.3: selectedObjectiveId will drive <ObjectivePanel>
+  const [selectedObjectiveId, setSelectedObjectiveId] = useState<string | null>(null);
 
   const { data: strategies } = useStrategiesQuery(analysisId);
   const { data: strategyTypes } = useStrategyTypesQuery();
@@ -348,9 +351,15 @@ export function DofaDetail({ analysisId, onBack }: Props) {
           </>
         )}
         {activePhase === 3 && (
-          <div className="p-10 text-center text-sm text-muted-foreground">
-            Fase 3 — Plan de objetivos (próximamente en Sprint 3)
-          </div>
+          <>
+            <PlanGrid
+              analysisId={analysisId}
+              readOnly={isReadOnly}
+              onSelectObjective={setSelectedObjectiveId}
+            />
+            {/* Sprint 3.3: wire ObjectivePanel when selectedObjectiveId is set */}
+            {selectedObjectiveId && null}
+          </>
         )}
       </div>
 

--- a/feature/planning/components/dofa/empty-block.tsx
+++ b/feature/planning/components/dofa/empty-block.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { LucideIcon } from "lucide-react";
+
+interface EmptyBlockProps {
+  icon: LucideIcon;
+  title: string;
+  description?: string;
+  cta?: React.ReactNode;
+  className?: string;
+}
+
+export function EmptyBlock({ icon: Icon, title, description, cta, className }: EmptyBlockProps) {
+  return (
+    <div className={cn("flex flex-col items-center text-center py-8", className)}>
+      <div className="h-12 w-12 rounded-full bg-muted flex items-center justify-center text-muted-foreground mb-3">
+        <Icon className="h-6 w-6" />
+      </div>
+      <p className="text-sm font-semibold">{title}</p>
+      {description && (
+        <p className="text-xs text-muted-foreground max-w-xs mt-1">{description}</p>
+      )}
+      {cta && <div className="mt-3">{cta}</div>}
+    </div>
+  );
+}

--- a/feature/planning/components/dofa/goal-form-dialog.tsx
+++ b/feature/planning/components/dofa/goal-form-dialog.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import toast from "react-hot-toast";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Card } from "@/components/ui/card";
+import {
+  useGoalStatusesQuery,
+  useCreateGoalMutation,
+  useUpdateGoalMutation,
+} from "@/feature/planning/hooks/use-dofa";
+import { GOAL_DEFAULTS, GOAL_STATUS_CFG, findDefaultGoalStatusId } from "./plan-helpers";
+import type { GoalDto, CatalogStatusDto } from "@/feature/planning/api/dofa";
+
+interface GoalFormDialogProps {
+  open: boolean;
+  goal: GoalDto | null;
+  objectiveId: string;
+  onClose: () => void;
+}
+
+interface FormState {
+  description: string;
+  targetValue: string;
+  currentValue: string;
+  baselineValue: string;
+  unit: string;
+  weight: string;
+  deadline: string;
+  statusId: string;
+}
+
+function initState(goal: GoalDto | null, statuses: CatalogStatusDto[]): FormState {
+  if (goal) {
+    return {
+      description: goal.description,
+      targetValue: String(goal.targetValue),
+      currentValue: String(goal.currentValue),
+      baselineValue: String(goal.baselineValue),
+      unit: goal.unit ?? "",
+      weight: String(goal.weight),
+      deadline: goal.deadline.slice(0, 10),
+      statusId: goal.statusId,
+    };
+  }
+  return {
+    description: "",
+    targetValue: "",
+    currentValue: String(GOAL_DEFAULTS.currentValue),
+    baselineValue: String(GOAL_DEFAULTS.baselineValue),
+    unit: "",
+    weight: String(GOAL_DEFAULTS.weight),
+    deadline: "",
+    statusId: findDefaultGoalStatusId(statuses) ?? "",
+  };
+}
+
+// Inner form — mounted fresh via key on each open/goal change
+interface GoalFormInnerProps {
+  goal: GoalDto | null;
+  objectiveId: string;
+  statuses: CatalogStatusDto[];
+  onClose: () => void;
+}
+
+function GoalFormInner({ goal, objectiveId, statuses, onClose }: GoalFormInnerProps) {
+  const isEdit = !!goal;
+  const createMutation = useCreateGoalMutation();
+  const updateMutation = useUpdateGoalMutation();
+
+  const [form, setForm] = useState<FormState>(() => initState(goal, statuses));
+
+  // Live progress calculation
+  const livePct = useMemo(() => {
+    const t = parseFloat(form.targetValue) || 0;
+    const c = parseFloat(form.currentValue) || 0;
+    const b = parseFloat(form.baselineValue) || 0;
+    if (t === b) return 0;
+    return Math.min(100, Math.max(0, Math.round(((c - b) / (t - b)) * 100)));
+  }, [form.targetValue, form.currentValue, form.baselineValue]);
+
+  const handleSubmit = async () => {
+    if (!form.description.trim()) { toast.error("La descripción es obligatoria"); return; }
+    if (!form.targetValue) { toast.error("El valor objetivo es obligatorio"); return; }
+    if (!form.deadline) { toast.error("La fecha límite es obligatoria"); return; }
+    if (!form.statusId) { toast.error("Selecciona un estado"); return; }
+
+    const sharedFields = {
+      description: form.description.trim(),
+      objectiveId,
+      targetValue: parseFloat(form.targetValue),
+      currentValue: parseFloat(form.currentValue) || 0,
+      baselineValue: parseFloat(form.baselineValue) || 0,
+      unit: form.unit || null,
+      weight: parseInt(form.weight) || GOAL_DEFAULTS.weight,
+      deadline: new Date(form.deadline + "T00:00:00Z").toISOString(),
+      statusId: form.statusId,
+      responsibleId: null,
+    };
+
+    try {
+      if (isEdit) {
+        await updateMutation.mutateAsync({
+          goalId: goal!.id,
+          payload: { id: goal!.id, ...sharedFields },
+        });
+        toast.success("Meta actualizada");
+      } else {
+        await createMutation.mutateAsync(sharedFields);
+        toast.success("Meta creada");
+      }
+      onClose();
+    } catch (e: any) {
+      toast.error(e?.response?.data?.message ?? e?.message ?? "Error al guardar");
+    }
+  };
+
+  const isPending = createMutation.isPending || updateMutation.isPending;
+
+  return (
+    <div className="space-y-4 py-2">
+      <div>
+        <Label>Descripción *</Label>
+        <Textarea
+          rows={2}
+          value={form.description}
+          onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+          placeholder="Aumentar 29% el nivel de satisfacción de los usuarios"
+          className="mt-1.5"
+        />
+      </div>
+
+      <div className="grid grid-cols-3 gap-2">
+        <div>
+          <Label>Línea base</Label>
+          <Input
+            type="number" step="any"
+            value={form.baselineValue}
+            onChange={(e) => setForm((f) => ({ ...f, baselineValue: e.target.value }))}
+            className="mt-1.5"
+          />
+        </div>
+        <div>
+          <Label>Actual</Label>
+          <Input
+            type="number" step="any"
+            value={form.currentValue}
+            onChange={(e) => setForm((f) => ({ ...f, currentValue: e.target.value }))}
+            className="mt-1.5"
+          />
+        </div>
+        <div>
+          <Label>Meta *</Label>
+          <Input
+            type="number" step="any"
+            value={form.targetValue}
+            onChange={(e) => setForm((f) => ({ ...f, targetValue: e.target.value }))}
+            className="mt-1.5"
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <Label>Unidad</Label>
+          <Input
+            value={form.unit}
+            onChange={(e) => setForm((f) => ({ ...f, unit: e.target.value }))}
+            placeholder="%, mm, $"
+            className="mt-1.5"
+          />
+        </div>
+        <div>
+          <Label>Peso (0-100)</Label>
+          <Input
+            type="number" min={0} max={100}
+            value={form.weight}
+            onChange={(e) => setForm((f) => ({ ...f, weight: e.target.value }))}
+            className="mt-1.5"
+          />
+        </div>
+      </div>
+
+      {/* Live progress calculation */}
+      <Card className="p-3 bg-muted/40">
+        <div className="flex items-center justify-between mb-1.5">
+          <span className="text-xs text-muted-foreground">Progreso calculado</span>
+          <span className="font-mono font-semibold text-sm">{livePct}%</span>
+        </div>
+        <div className="w-full h-1.5 rounded-full bg-muted overflow-hidden">
+          <div
+            className="h-full rounded-full bg-emerald-500 transition-all duration-200"
+            style={{ width: `${livePct}%` }}
+          />
+        </div>
+      </Card>
+
+      <div>
+        <Label>Estado *</Label>
+        <Select
+          value={form.statusId}
+          onValueChange={(v) => setForm((f) => ({ ...f, statusId: v }))}
+        >
+          <SelectTrigger className="mt-1.5">
+            <SelectValue placeholder="Seleccionar..." />
+          </SelectTrigger>
+          <SelectContent>
+            {statuses
+              .filter((s) => GOAL_STATUS_CFG[s.code])
+              .map((s) => (
+                <SelectItem key={s.id} value={s.id}>
+                  {GOAL_STATUS_CFG[s.code].label}
+                </SelectItem>
+              ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div>
+        <Label>Fecha límite *</Label>
+        <Input
+          type="date"
+          value={form.deadline}
+          onChange={(e) => setForm((f) => ({ ...f, deadline: e.target.value }))}
+          className="mt-1.5"
+        />
+      </div>
+
+      <DialogFooter>
+        <Button variant="ghost" onClick={onClose} disabled={isPending}>
+          Cancelar
+        </Button>
+        <Button onClick={handleSubmit} disabled={isPending}>
+          {isPending ? "Guardando..." : isEdit ? "Guardar" : "Crear meta"}
+        </Button>
+      </DialogFooter>
+    </div>
+  );
+}
+
+export function GoalFormDialog({ open, goal, objectiveId, onClose }: GoalFormDialogProps) {
+  const { data: statuses = [] } = useGoalStatusesQuery();
+  const isEdit = !!goal;
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? "Editar meta" : "Nueva meta"}</DialogTitle>
+        </DialogHeader>
+        {/* key forces remount (fresh state) when switching between create/edit or different goals */}
+        <GoalFormInner
+          key={goal?.id ?? "new"}
+          goal={goal}
+          objectiveId={objectiveId}
+          statuses={statuses}
+          onClose={onClose}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/feature/planning/components/dofa/goal-form-dialog.tsx
+++ b/feature/planning/components/dofa/goal-form-dialog.tsx
@@ -110,7 +110,7 @@ function GoalFormInner({ goal, objectiveId, statuses, onClose }: GoalFormInnerPr
       baselineValue: parseFloat(form.baselineValue) || 0,
       unit: form.unit || null,
       weight: parseInt(form.weight) || GOAL_DEFAULTS.weight,
-      deadline: new Date(form.deadline + "T00:00:00Z").toISOString(),
+      deadline: new Date(form.deadline + "T12:00:00").toISOString(),
       statusId: form.statusId,
       responsibleId: null,
     };

--- a/feature/planning/components/dofa/goal-progress-bar.tsx
+++ b/feature/planning/components/dofa/goal-progress-bar.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { GoalDto } from "@/feature/planning/api/dofa";
+
+interface GoalProgressBarProps {
+  goal: Pick<
+    GoalDto,
+    "currentValue" | "baselineValue" | "targetValue" | "unit" | "progressPercentage"
+  >;
+  className?: string;
+}
+
+const TONE = (v: number) => {
+  if (v >= 100) return { text: "text-emerald-500", bg: "bg-emerald-500" };
+  if (v >= 60) return { text: "text-sky-500", bg: "bg-sky-500" };
+  if (v >= 30) return { text: "text-amber-500", bg: "bg-amber-500" };
+  return { text: "text-rose-500", bg: "bg-rose-500" };
+};
+
+export function GoalProgressBar({ goal, className }: GoalProgressBarProps) {
+  const pct = Math.max(0, Math.min(100, goal.progressPercentage ?? 0));
+  const tone = TONE(pct);
+  const unit = goal.unit ?? "";
+
+  return (
+    <div className={cn("space-y-1", className)}>
+      <div className="flex justify-between items-center text-xs">
+        <span className="text-muted-foreground">
+          {goal.currentValue} {unit} / {goal.targetValue} {unit}
+        </span>
+        <span className={cn("font-mono font-semibold", tone.text)}>{pct}%</span>
+      </div>
+      <div className="h-1.5 bg-border rounded-full overflow-hidden">
+        <div
+          className={cn("h-full transition-all duration-300", tone.bg)}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <div className="flex justify-between text-[10px] text-muted-foreground">
+        <span>Base: {goal.baselineValue}</span>
+        <span>Meta: {goal.targetValue}</span>
+      </div>
+    </div>
+  );
+}

--- a/feature/planning/components/dofa/goal-row.tsx
+++ b/feature/planning/components/dofa/goal-row.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { format } from "date-fns";
+import { CalendarDays, Pencil, Trash2 } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { GoalProgressBar } from "./goal-progress-bar";
+import { GOAL_STATUS_CFG, lookupStatusCode } from "./plan-helpers";
+import type { GoalDto, CatalogStatusDto } from "@/feature/planning/api/dofa";
+
+interface GoalRowProps {
+  goal: GoalDto;
+  statuses: CatalogStatusDto[];
+  onEdit: () => void;
+  onDelete: () => void;
+  readOnly?: boolean;
+}
+
+export function GoalRow({ goal, statuses, onEdit, onDelete, readOnly }: GoalRowProps) {
+  const code = lookupStatusCode(goal.statusId, statuses, "Defined");
+  const cfg = GOAL_STATUS_CFG[code] ?? GOAL_STATUS_CFG.Defined;
+
+  const fmtDate = (iso: string) => {
+    try {
+      return format(new Date(iso), "dd/MM/yyyy");
+    } catch {
+      return iso;
+    }
+  };
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-start gap-3">
+        <div className="flex-1 min-w-0 space-y-2">
+          <h4 className="text-sm font-semibold leading-snug">{goal.description}</h4>
+          <GoalProgressBar goal={goal} />
+          <div className="flex flex-wrap items-center gap-2 text-xs">
+            <Badge variant="outline" className="gap-1.5 h-5 px-1.5 text-[10px]">
+              <span className={`inline-block w-1.5 h-1.5 rounded-full ${cfg.dotClass}`} />
+              {cfg.label}
+            </Badge>
+            <span className="text-muted-foreground flex items-center gap-1">
+              <CalendarDays className="h-3 w-3" />
+              {fmtDate(goal.deadline)}
+            </span>
+            <span className="text-muted-foreground">Peso {goal.weight}%</span>
+          </div>
+        </div>
+        {!readOnly && (
+          <div className="flex gap-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={onEdit}
+              aria-label="Editar meta"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-destructive"
+              onClick={onDelete}
+              aria-label="Eliminar meta"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/feature/planning/components/dofa/indicator-accordion.tsx
+++ b/feature/planning/components/dofa/indicator-accordion.tsx
@@ -25,7 +25,7 @@ import {
   useIndicatorTypesQuery,
 } from "@/feature/planning/hooks/use-dofa";
 import { Sparkline } from "./sparkline";
-import { lookupCatalogName, lookupTrendSymbol } from "./plan-helpers";
+import { lookupCatalogName } from "./plan-helpers";
 import { MeasurementFormDialog } from "./measurement-form-dialog";
 import type { IndicatorDto, MeasurementDto } from "@/feature/planning/api/dofa";
 
@@ -52,7 +52,15 @@ export function IndicatorAccordion({ indicator, goalId, onEdit, readOnly }: Prop
 
   const freqName = lookupCatalogName(indicator.frequencyId, frequencies);
   const typeName = lookupCatalogName(indicator.indicatorTypeId, indicatorTypes);
-  const trendSymbol = lookupTrendSymbol(indicator.trendId, trends);
+  const trend = trends.find((t) => t.id === indicator.trendId);
+  const trendSymbol = trend?.symbol ?? null;
+  const trendColorClass = trend
+    ? trend.code === "Increasing"
+      ? "text-emerald-500"
+      : trend.code === "Decreasing"
+      ? "text-rose-500"
+      : "text-slate-500"
+    : "text-muted-foreground";
 
   const deleteIndMutation = useDeleteIndicatorMutation();
   const deleteMeasMutation = useDeleteMeasurementMutation();
@@ -106,14 +114,14 @@ export function IndicatorAccordion({ indicator, goalId, onEdit, readOnly }: Prop
         <div className="flex-1 min-w-0">
           <div className="text-sm font-semibold leading-snug">{indicator.name}</div>
           <div className="flex flex-wrap items-center gap-1.5 mt-1.5">
-            <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
+            <Badge className="h-5 px-1.5 text-[10px] bg-sky-100 text-sky-700 border-0">
               {freqName}
             </Badge>
-            <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
+            <Badge className="h-5 px-1.5 text-[10px] bg-muted text-muted-foreground border-0">
               {typeName}
             </Badge>
             {trendSymbol && (
-              <span className="text-xs text-muted-foreground">{trendSymbol}</span>
+              <span className={`text-xs font-medium ${trendColorClass}`}>{trendSymbol}</span>
             )}
             {indicator.dataSource && (
               <span className="text-[10px] text-muted-foreground">
@@ -128,8 +136,8 @@ export function IndicatorAccordion({ indicator, goalId, onEdit, readOnly }: Prop
             className="flex items-center gap-2"
             onClick={(e) => e.stopPropagation()}
           >
-            <Sparkline values={sparklineValues} />
-            <span className="text-xs font-mono text-sky-500 font-semibold">
+            <Sparkline values={sparklineValues} width={100} height={28} />
+            <span className="text-sm font-mono font-semibold text-sky-500">
               {lastValue}
             </span>
           </div>

--- a/feature/planning/components/dofa/indicator-accordion.tsx
+++ b/feature/planning/components/dofa/indicator-accordion.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useState } from "react";
+import toast from "react-hot-toast";
+import { ChevronRight, Pencil, Plus, Trash2, Link as LinkIcon } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import { fmtDate } from "@/lib/format";
+import {
+  useIndicatorDetailQuery,
+  useDeleteIndicatorMutation,
+  useDeleteMeasurementMutation,
+  useGoalFrequenciesQuery,
+  useGoalTrendsQuery,
+  useIndicatorTypesQuery,
+} from "@/feature/planning/hooks/use-dofa";
+import { Sparkline } from "./sparkline";
+import { lookupCatalogName, lookupTrendSymbol } from "./plan-helpers";
+import { MeasurementFormDialog } from "./measurement-form-dialog";
+import type { IndicatorDto, MeasurementDto } from "@/feature/planning/api/dofa";
+
+interface Props {
+  indicator: IndicatorDto;
+  goalId: string;
+  onEdit: () => void;
+  readOnly?: boolean;
+}
+
+export function IndicatorAccordion({ indicator, goalId, onEdit, readOnly }: Props) {
+  const [expanded, setExpanded] = useState(false);
+
+  // PM-14: lazy load detail only when expanded
+  const { data: detail } = useIndicatorDetailQuery(goalId, indicator.id, {
+    enabled: expanded,
+  });
+  const measurements = detail?.measurements ?? [];
+
+  // PM-18: client-side lookup
+  const { data: frequencies = [] } = useGoalFrequenciesQuery();
+  const { data: indicatorTypes = [] } = useIndicatorTypesQuery();
+  const { data: trends = [] } = useGoalTrendsQuery();
+
+  const freqName = lookupCatalogName(indicator.frequencyId, frequencies);
+  const typeName = lookupCatalogName(indicator.indicatorTypeId, indicatorTypes);
+  const trendSymbol = lookupTrendSymbol(indicator.trendId, trends);
+
+  const deleteIndMutation = useDeleteIndicatorMutation();
+  const deleteMeasMutation = useDeleteMeasurementMutation();
+
+  const [measDialog, setMeasDialog] = useState<{
+    open: boolean;
+    meas: MeasurementDto | null;
+  }>({ open: false, meas: null });
+
+  // Sparkline: last 10 measurements in chronological order
+  const sparklineValues = [...measurements]
+    .sort((a, b) => a.measurementDate.localeCompare(b.measurementDate))
+    .slice(-10)
+    .map((m) => m.value);
+  const lastValue = sparklineValues[sparklineValues.length - 1];
+
+  const handleDeleteIndicator = async () => {
+    if (!confirm(`¿Eliminar el indicador "${indicator.name}"?`)) return;
+    try {
+      await deleteIndMutation.mutateAsync({ goalId, indicatorId: indicator.id });
+      toast.success("Indicador eliminado");
+    } catch {
+      toast.error("Error al eliminar");
+    }
+  };
+
+  const handleDeleteMeasurement = async (measurementId: string) => {
+    if (!confirm("¿Eliminar esta medición?")) return;
+    try {
+      await deleteMeasMutation.mutateAsync({
+        indicatorId: indicator.id,
+        goalId,
+        measurementId,
+      });
+      toast.success("Medición eliminada");
+    } catch {
+      toast.error("Error al eliminar");
+    }
+  };
+
+  return (
+    <Card className="overflow-hidden">
+      {/* Clickable header */}
+      <div
+        className="flex items-center gap-2 p-3 cursor-pointer hover:bg-muted/40"
+        onClick={() => setExpanded((e) => !e)}
+      >
+        <ChevronRight
+          className={cn("h-4 w-4 transition-transform", expanded && "rotate-90")}
+        />
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-semibold leading-snug">{indicator.name}</div>
+          <div className="flex flex-wrap items-center gap-1.5 mt-1.5">
+            <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
+              {freqName}
+            </Badge>
+            <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
+              {typeName}
+            </Badge>
+            {trendSymbol && (
+              <span className="text-xs text-muted-foreground">{trendSymbol}</span>
+            )}
+            {indicator.dataSource && (
+              <span className="text-[10px] text-muted-foreground">
+                📁 {indicator.dataSource}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {sparklineValues.length >= 2 && (
+          <div
+            className="flex items-center gap-2"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Sparkline values={sparklineValues} />
+            <span className="text-xs font-mono text-sky-500 font-semibold">
+              {lastValue}
+            </span>
+          </div>
+        )}
+
+        {!readOnly && (
+          <div className="flex gap-1" onClick={(e) => e.stopPropagation()}>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={onEdit}
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-destructive"
+              onClick={handleDeleteIndicator}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {/* Expanded body */}
+      {expanded && (
+        <div className="border-t p-3 space-y-3">
+          {indicator.formula && (
+            <code className="block text-xs bg-muted px-2 py-1.5 rounded font-mono">
+              f(x) = {indicator.formula}
+            </code>
+          )}
+
+          {measurements.length === 0 ? (
+            <p className="text-xs text-muted-foreground text-center py-4">
+              Sin mediciones registradas
+            </p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Fecha</TableHead>
+                  <TableHead>Valor</TableHead>
+                  <TableHead>Observaciones</TableHead>
+                  <TableHead>Evidencia</TableHead>
+                  {!readOnly && <TableHead className="w-16" />}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {[...measurements]
+                  .sort((a, b) =>
+                    b.measurementDate.localeCompare(a.measurementDate)
+                  )
+                  .map((m) => (
+                    <TableRow key={m.id}>
+                      <TableCell className="font-mono text-xs">
+                        {fmtDate(m.measurementDate)}
+                      </TableCell>
+                      <TableCell className="font-mono font-semibold text-sky-500">
+                        {m.value}
+                      </TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {m.observations || "—"}
+                      </TableCell>
+                      <TableCell>
+                        {m.evidenceUrl ? (
+                          <a
+                            href={m.evidenceUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-xs text-sky-500 inline-flex items-center gap-1"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <LinkIcon className="h-3 w-3" />
+                            Ver
+                          </a>
+                        ) : (
+                          "—"
+                        )}
+                      </TableCell>
+                      {!readOnly && (
+                        <TableCell>
+                          <div className="flex gap-1">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-6 w-6"
+                              onClick={() => setMeasDialog({ open: true, meas: m })}
+                            >
+                              <Pencil className="h-3 w-3" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-6 w-6 text-destructive"
+                              onClick={() => handleDeleteMeasurement(m.id)}
+                            >
+                              <Trash2 className="h-3 w-3" />
+                            </Button>
+                          </div>
+                        </TableCell>
+                      )}
+                    </TableRow>
+                  ))}
+              </TableBody>
+            </Table>
+          )}
+
+          {!readOnly && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full gap-1.5"
+              onClick={() => setMeasDialog({ open: true, meas: null })}
+            >
+              <Plus className="h-3.5 w-3.5" /> Nueva medición
+            </Button>
+          )}
+
+          <MeasurementFormDialog
+            open={measDialog.open}
+            indicatorId={indicator.id}
+            goalId={goalId}
+            measurement={measDialog.meas}
+            onClose={() => setMeasDialog({ open: false, meas: null })}
+          />
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/feature/planning/components/dofa/indicator-form-dialog.tsx
+++ b/feature/planning/components/dofa/indicator-form-dialog.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useState } from "react";
+import toast from "react-hot-toast";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  useGoalFrequenciesQuery,
+  useIndicatorTypesQuery,
+  useGoalTrendsQuery,
+  useCreateIndicatorMutation,
+  useUpdateIndicatorMutation,
+} from "@/feature/planning/hooks/use-dofa";
+import type { IndicatorDto } from "@/feature/planning/api/dofa";
+
+interface Props {
+  open: boolean;
+  indicator: IndicatorDto | null;
+  goalId: string;
+  onClose: () => void;
+}
+
+interface FormState {
+  name: string;
+  frequencyId: string;
+  indicatorTypeId: string;
+  trendId: string;
+  formula: string;
+  dataSource: string;
+}
+
+function initState(indicator: IndicatorDto | null): FormState {
+  if (indicator) {
+    return {
+      name: indicator.name,
+      frequencyId: indicator.frequencyId,
+      indicatorTypeId: indicator.indicatorTypeId,
+      trendId: indicator.trendId ?? "",
+      formula: indicator.formula ?? "",
+      dataSource: indicator.dataSource ?? "",
+    };
+  }
+  return {
+    name: "",
+    frequencyId: "",
+    indicatorTypeId: "",
+    trendId: "",
+    formula: "",
+    dataSource: "",
+  };
+}
+
+interface InnerProps {
+  indicator: IndicatorDto | null;
+  goalId: string;
+  onClose: () => void;
+}
+
+function IndicatorFormInner({ indicator, goalId, onClose }: InnerProps) {
+  const isEdit = !!indicator;
+  const [form, setForm] = useState<FormState>(() => initState(indicator));
+
+  const { data: frequencies = [] } = useGoalFrequenciesQuery();
+  const { data: indicatorTypes = [] } = useIndicatorTypesQuery();
+  const { data: trends = [] } = useGoalTrendsQuery();
+
+  const createMutation = useCreateIndicatorMutation();
+  const updateMutation = useUpdateIndicatorMutation();
+
+  const handleSubmit = async () => {
+    if (!form.name.trim()) { toast.error("El nombre es obligatorio"); return; }
+    if (!form.frequencyId) { toast.error("Selecciona una frecuencia"); return; }
+    if (!form.indicatorTypeId) { toast.error("Selecciona un tipo de indicador"); return; }
+
+    const payload = {
+      name: form.name.trim(),
+      frequencyId: form.frequencyId,
+      indicatorTypeId: form.indicatorTypeId,
+      trendId: form.trendId || null,
+      formula: form.formula || null,
+      dataSource: form.dataSource || null,
+      responsibleId: null,
+    };
+
+    try {
+      if (isEdit) {
+        await updateMutation.mutateAsync({
+          goalId,
+          indicatorId: indicator!.id,
+          payload,
+        });
+        toast.success("Indicador actualizado");
+      } else {
+        await createMutation.mutateAsync({ goalId, payload });
+        toast.success("Indicador creado");
+      }
+      onClose();
+    } catch (e: any) {
+      toast.error(e?.response?.data?.message ?? e?.message ?? "Error al guardar");
+    }
+  };
+
+  const isPending = createMutation.isPending || updateMutation.isPending;
+
+  return (
+    <div className="space-y-4 py-2">
+      <div>
+        <Label>Nombre *</Label>
+        <Input
+          value={form.name}
+          onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+          placeholder="Tasa de satisfacción del cliente"
+          className="mt-1.5"
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <Label>Frecuencia *</Label>
+          <Select
+            value={form.frequencyId}
+            onValueChange={(v) => setForm((f) => ({ ...f, frequencyId: v }))}
+          >
+            <SelectTrigger className="mt-1.5">
+              <SelectValue placeholder="Seleccionar..." />
+            </SelectTrigger>
+            <SelectContent>
+              {frequencies.map((freq) => (
+                <SelectItem key={freq.id} value={freq.id}>
+                  {freq.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div>
+          <Label>Tipo de indicador *</Label>
+          <Select
+            value={form.indicatorTypeId}
+            onValueChange={(v) => setForm((f) => ({ ...f, indicatorTypeId: v }))}
+          >
+            <SelectTrigger className="mt-1.5">
+              <SelectValue placeholder="Seleccionar..." />
+            </SelectTrigger>
+            <SelectContent>
+              {indicatorTypes.map((t) => (
+                <SelectItem key={t.id} value={t.id}>
+                  {t.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div>
+        <Label>Tendencia esperada</Label>
+        <Select
+          value={form.trendId}
+          onValueChange={(v) => setForm((f) => ({ ...f, trendId: v }))}
+        >
+          <SelectTrigger className="mt-1.5">
+            <SelectValue placeholder="Sin tendencia" />
+          </SelectTrigger>
+          <SelectContent>
+            {trends.map((t) => (
+              <SelectItem key={t.id} value={t.id}>
+                {t.symbol} {t.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div>
+        <Label>Fórmula</Label>
+        <Textarea
+          rows={2}
+          value={form.formula}
+          onChange={(e) => setForm((f) => ({ ...f, formula: e.target.value }))}
+          placeholder="(Valor actual / Valor objetivo) × 100"
+          className="mt-1.5"
+        />
+      </div>
+
+      <div>
+        <Label>Fuente de datos</Label>
+        <Input
+          value={form.dataSource}
+          onChange={(e) => setForm((f) => ({ ...f, dataSource: e.target.value }))}
+          placeholder="CRM, encuesta NPS, sistema contable..."
+          className="mt-1.5"
+        />
+      </div>
+
+      <DialogFooter>
+        <Button variant="ghost" onClick={onClose} disabled={isPending}>
+          Cancelar
+        </Button>
+        <Button onClick={handleSubmit} disabled={isPending}>
+          {isPending ? "Guardando..." : isEdit ? "Guardar" : "Crear indicador"}
+        </Button>
+      </DialogFooter>
+    </div>
+  );
+}
+
+export function IndicatorFormDialog({ open, indicator, goalId, onClose }: Props) {
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{indicator ? "Editar indicador" : "Nuevo indicador"}</DialogTitle>
+        </DialogHeader>
+        <IndicatorFormInner
+          key={indicator?.id ?? "new"}
+          indicator={indicator}
+          goalId={goalId}
+          onClose={onClose}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/feature/planning/components/dofa/measurement-form-dialog.tsx
+++ b/feature/planning/components/dofa/measurement-form-dialog.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import toast from "react-hot-toast";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  useCreateMeasurementMutation,
+  useUpdateMeasurementMutation,
+} from "@/feature/planning/hooks/use-dofa";
+import type { MeasurementDto } from "@/feature/planning/api/dofa";
+
+interface Props {
+  open: boolean;
+  indicatorId: string;
+  goalId: string;
+  measurement: MeasurementDto | null;
+  onClose: () => void;
+}
+
+const INIT = () => ({
+  measurementDate: new Date().toISOString().slice(0, 10),
+  value: "",
+  observations: "",
+  evidenceUrl: "",
+});
+
+export function MeasurementFormDialog({
+  open,
+  indicatorId,
+  goalId,
+  measurement,
+  onClose,
+}: Props) {
+  const isEdit = !!measurement;
+  const [form, setForm] = useState(INIT());
+  const createMutation = useCreateMeasurementMutation();
+  const updateMutation = useUpdateMeasurementMutation();
+
+  useEffect(() => {
+    if (!open) return;
+    if (measurement) {
+      setForm({
+        measurementDate: measurement.measurementDate.slice(0, 10),
+        value: String(measurement.value),
+        observations: measurement.observations ?? "",
+        evidenceUrl: measurement.evidenceUrl ?? "",
+      });
+    } else {
+      setForm(INIT());
+    }
+  }, [open, measurement]);
+
+  const handleSubmit = async () => {
+    if (!form.value) { toast.error("El valor es obligatorio"); return; }
+    if (!form.measurementDate) { toast.error("La fecha es obligatoria"); return; }
+
+    const payload = {
+      value: parseFloat(form.value),
+      measurementDate: new Date(form.measurementDate + "T00:00:00Z").toISOString(),
+      goalIndicatorId: indicatorId,
+      observations: form.observations || null,
+      evidenceUrl: form.evidenceUrl || null,
+    };
+
+    try {
+      if (isEdit) {
+        await updateMutation.mutateAsync({
+          indicatorId,
+          goalId,
+          measurementId: measurement!.id,
+          payload,
+        });
+        toast.success("Medición actualizada");
+      } else {
+        await createMutation.mutateAsync({ indicatorId, goalId, payload });
+        toast.success("Medición registrada");
+      }
+      onClose();
+    } catch (e: any) {
+      toast.error(e?.response?.data?.detail ?? e?.message ?? "Error al guardar");
+    }
+  };
+
+  const isPending = createMutation.isPending || updateMutation.isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{isEdit ? "Editar medición" : "Nueva medición"}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <Label>Fecha *</Label>
+              <Input
+                type="date"
+                value={form.measurementDate}
+                onChange={(e) => setForm((f) => ({ ...f, measurementDate: e.target.value }))}
+                disabled={isEdit}
+                className="mt-1.5"
+              />
+            </div>
+            <div>
+              <Label>Valor *</Label>
+              <Input
+                type="number"
+                step="any"
+                placeholder="0.00"
+                value={form.value}
+                onChange={(e) => setForm((f) => ({ ...f, value: e.target.value }))}
+                className="mt-1.5"
+              />
+            </div>
+          </div>
+
+          <div>
+            <Label>Observaciones</Label>
+            <Textarea
+              rows={2}
+              value={form.observations}
+              onChange={(e) => setForm((f) => ({ ...f, observations: e.target.value }))}
+              placeholder="Notas sobre esta medición..."
+              className="mt-1.5"
+            />
+          </div>
+
+          <div>
+            <Label>URL de evidencia</Label>
+            <Input
+              type="url"
+              placeholder="https://..."
+              value={form.evidenceUrl}
+              onChange={(e) => setForm((f) => ({ ...f, evidenceUrl: e.target.value }))}
+              className="mt-1.5"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose} disabled={isPending}>
+            Cancelar
+          </Button>
+          <Button onClick={handleSubmit} disabled={isPending}>
+            {isPending ? "Guardando..." : isEdit ? "Guardar" : "Registrar"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/feature/planning/components/dofa/measurement-form-dialog.tsx
+++ b/feature/planning/components/dofa/measurement-form-dialog.tsx
@@ -66,7 +66,7 @@ export function MeasurementFormDialog({
 
     const payload = {
       value: parseFloat(form.value),
-      measurementDate: new Date(form.measurementDate + "T00:00:00Z").toISOString(),
+      measurementDate: new Date(form.measurementDate + "T12:00:00").toISOString(),
       goalIndicatorId: indicatorId,
       observations: form.observations || null,
       evidenceUrl: form.evidenceUrl || null,

--- a/feature/planning/components/dofa/objective-card.tsx
+++ b/feature/planning/components/dofa/objective-card.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { ProgressRing } from "./progress-ring";
+import { OBJECTIVE_STATUS_CFG } from "./plan-helpers";
+import type { ObjectiveDto } from "@/feature/planning/api/dofa";
+
+interface ObjectiveCardProps {
+  objective: ObjectiveDto;
+  goalsCount: number;
+  origins: { code: string; description: string }[];
+  /** Accepts ObjectiveStatusDto[] or CatalogStatusDto[] — only id/code are used */
+  statuses: { id: string; code: string }[];
+  onClick: () => void;
+}
+
+export function ObjectiveCard({
+  objective,
+  goalsCount,
+  origins,
+  statuses,
+  onClick,
+}: ObjectiveCardProps) {
+  const code =
+    statuses.find((s) => s.id === objective.statusId)?.code ?? "Planned";
+  const cfg = OBJECTIVE_STATUS_CFG[code] ?? OBJECTIVE_STATUS_CFG.Planned;
+
+  return (
+    <Card
+      className="cursor-pointer hover:shadow-md transition-shadow p-4"
+      onClick={onClick}
+    >
+      <div className="flex items-start gap-3">
+        <ProgressRing value={objective.progressPercentage} size={44} />
+        <div className="flex-1 min-w-0">
+          <h3 className="text-sm font-semibold leading-snug truncate">{objective.name}</h3>
+          {objective.description && (
+            <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
+              {objective.description}
+            </p>
+          )}
+          <div className="flex items-center gap-2 mt-2 text-xs text-muted-foreground">
+            <span>
+              {goalsCount} {goalsCount === 1 ? "meta" : "metas"}
+            </span>
+            <span>•</span>
+            <Badge variant="outline" className="gap-1.5 h-5 px-1.5 text-[10px]">
+              <span className={`inline-block w-1.5 h-1.5 rounded-full ${cfg.dotClass}`} />
+              {cfg.label}
+            </Badge>
+          </div>
+          {origins.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1 mt-2">
+              <span className="text-[10px] text-muted-foreground">Origen:</span>
+              {origins.map((s, i) => (
+                <Badge
+                  key={i}
+                  variant="outline"
+                  className="h-5 px-1.5 text-[10px] bg-muted/60"
+                  title={s.description}
+                >
+                  {s.code}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/feature/planning/components/dofa/objective-card.tsx
+++ b/feature/planning/components/dofa/objective-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { format } from "date-fns";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { ProgressRing } from "./progress-ring";
@@ -28,11 +29,11 @@ export function ObjectiveCard({
 
   return (
     <Card
-      className="cursor-pointer hover:shadow-md transition-shadow p-4"
+      className="cursor-pointer hover:shadow-md hover:border-sky-200 transition-all active:scale-[0.99] p-4"
       onClick={onClick}
     >
       <div className="flex items-start gap-3">
-        <ProgressRing value={objective.progressPercentage} size={44} />
+        <ProgressRing value={objective.progressPercentage} size={48} />
         <div className="flex-1 min-w-0">
           <h3 className="text-sm font-semibold leading-snug truncate">{objective.name}</h3>
           {objective.description && (
@@ -40,7 +41,7 @@ export function ObjectiveCard({
               {objective.description}
             </p>
           )}
-          <div className="flex items-center gap-2 mt-2 text-xs text-muted-foreground">
+          <div className="flex flex-wrap items-center gap-2 mt-2 text-xs text-muted-foreground">
             <span>
               {goalsCount} {goalsCount === 1 ? "meta" : "metas"}
             </span>
@@ -49,6 +50,11 @@ export function ObjectiveCard({
               <span className={`inline-block w-1.5 h-1.5 rounded-full ${cfg.dotClass}`} />
               {cfg.label}
             </Badge>
+            {objective.endDate && (
+              <Badge variant="outline" className="h-5 px-1.5 text-[10px] text-muted-foreground">
+                Vence {format(new Date(objective.endDate), "dd/MM/yyyy")}
+              </Badge>
+            )}
           </div>
           {origins.length > 0 && (
             <div className="flex flex-wrap items-center gap-1 mt-2">

--- a/feature/planning/components/dofa/objective-panel.tsx
+++ b/feature/planning/components/dofa/objective-panel.tsx
@@ -37,11 +37,11 @@ export function ObjectivePanel({ objectiveId, onClose, readOnly }: ObjectivePane
 
   return (
     <Sheet open={isOpen} onOpenChange={(o) => !o && onClose()}>
-      <SheetContent className="sm:max-w-3xl overflow-y-auto">
+      <SheetContent className="sm:max-w-3xl overflow-y-auto p-6 sm:p-8">
         {/* sr-only title keeps Radix aria-labelledby valid when the visual header is custom */}
-        <SheetTitle className="sr-only">{objective?.name ?? "Objetivo estratégico"}</SheetTitle>
-        <SheetHeader className="pb-0">
-          <div className="flex items-start gap-3 pb-4 border-b border-border">
+        <SheetTitle className="sr-only">{objective?.name ?? "Detalle del objetivo"}</SheetTitle>
+        <SheetHeader className="p-0">
+          <div className="flex items-start gap-3 pb-6 border-b border-border">
             <ProgressRing value={objective?.progressPercentage ?? 0} size={56} />
             <div className="flex-1 min-w-0">
               {isLoading ? (
@@ -79,7 +79,7 @@ export function ObjectivePanel({ objectiveId, onClose, readOnly }: ObjectivePane
         </SheetHeader>
 
         {objectiveId && (
-          <Tabs defaultValue="description" className="mt-4">
+          <Tabs defaultValue="description" className="mt-6">
             <TabsList className="grid w-full grid-cols-4">
               <TabsTrigger value="description">Descripción</TabsTrigger>
               <TabsTrigger value="goals">Metas</TabsTrigger>

--- a/feature/planning/components/dofa/objective-panel.tsx
+++ b/feature/planning/components/dofa/objective-panel.tsx
@@ -38,6 +38,8 @@ export function ObjectivePanel({ objectiveId, onClose, readOnly }: ObjectivePane
   return (
     <Sheet open={isOpen} onOpenChange={(o) => !o && onClose()}>
       <SheetContent className="sm:max-w-3xl overflow-y-auto">
+        {/* sr-only title keeps Radix aria-labelledby valid when the visual header is custom */}
+        <SheetTitle className="sr-only">{objective?.name ?? "Objetivo estratégico"}</SheetTitle>
         <SheetHeader className="pb-0">
           <div className="flex items-start gap-3 pb-4 border-b border-border">
             <ProgressRing value={objective?.progressPercentage ?? 0} size={56} />

--- a/feature/planning/components/dofa/objective-panel.tsx
+++ b/feature/planning/components/dofa/objective-panel.tsx
@@ -9,6 +9,8 @@ import { ProgressRing } from "./progress-ring";
 import { OBJECTIVE_STATUS_CFG } from "./plan-helpers";
 import { TabObjectiveDescription } from "./tab-objective-description";
 import { TabObjectiveGoals } from "./tab-objective-goals";
+import { TabObjectiveIndicators } from "./tab-objective-indicators";
+import { TabObjectiveMeasurements } from "./tab-objective-measurements";
 
 interface ObjectivePanelProps {
   objectiveId: string | null;
@@ -57,8 +59,8 @@ export function ObjectivePanel({ objectiveId, onClose, readOnly }: ObjectivePane
             <TabsList className="grid w-full grid-cols-4">
               <TabsTrigger value="description">Descripción</TabsTrigger>
               <TabsTrigger value="goals">Metas</TabsTrigger>
-              <TabsTrigger value="indicators" disabled>Indicadores</TabsTrigger>
-              <TabsTrigger value="measurements" disabled>Mediciones</TabsTrigger>
+              <TabsTrigger value="indicators">Indicadores</TabsTrigger>
+              <TabsTrigger value="measurements">Mediciones</TabsTrigger>
             </TabsList>
             <TabsContent value="description" className="mt-4">
               {objective ? (
@@ -77,6 +79,12 @@ export function ObjectivePanel({ objectiveId, onClose, readOnly }: ObjectivePane
             </TabsContent>
             <TabsContent value="goals" className="mt-4">
               <TabObjectiveGoals objectiveId={objectiveId} readOnly={readOnly} />
+            </TabsContent>
+            <TabsContent value="indicators" className="mt-4">
+              <TabObjectiveIndicators objectiveId={objectiveId} readOnly={readOnly} />
+            </TabsContent>
+            <TabsContent value="measurements" className="mt-4">
+              <TabObjectiveMeasurements objectiveId={objectiveId} />
             </TabsContent>
           </Tabs>
         )}

--- a/feature/planning/components/dofa/objective-panel.tsx
+++ b/feature/planning/components/dofa/objective-panel.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { format } from "date-fns";
+import { CalendarDays, User } from "lucide-react";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
@@ -29,25 +31,45 @@ export function ObjectivePanel({ objectiveId, onClose, readOnly }: ObjectivePane
       : "Planned";
   const cfg = OBJECTIVE_STATUS_CFG[code] ?? OBJECTIVE_STATUS_CFG.Planned;
 
+  const fmtDate = (iso: string) => {
+    try { return format(new Date(iso), "dd/MM/yyyy"); } catch { return iso; }
+  };
+
   return (
     <Sheet open={isOpen} onOpenChange={(o) => !o && onClose()}>
       <SheetContent className="sm:max-w-3xl overflow-y-auto">
-        <SheetHeader className="space-y-2">
-          <div className="flex items-center gap-3">
-            <ProgressRing value={objective?.progressPercentage ?? 0} size={36} />
+        <SheetHeader className="pb-0">
+          <div className="flex items-start gap-3 pb-4 border-b border-border">
+            <ProgressRing value={objective?.progressPercentage ?? 0} size={56} />
             <div className="flex-1 min-w-0">
               {isLoading ? (
                 <Skeleton className="h-5 w-48" />
               ) : (
-                <SheetTitle className="truncate">{objective?.name ?? "..."}</SheetTitle>
+                <SheetTitle className="text-base leading-snug">
+                  {objective?.name ?? "..."}
+                </SheetTitle>
               )}
               {objective?.description && (
-                <p className="text-xs text-muted-foreground line-clamp-2 mt-1">
+                <p className="text-xs text-muted-foreground line-clamp-1 mt-0.5">
                   {objective.description}
                 </p>
               )}
+              {objective && (
+                <div className="flex flex-wrap items-center gap-3 mt-1.5">
+                  <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
+                    <CalendarDays className="h-3 w-3" />
+                    {fmtDate(objective.startDate)} – {fmtDate(objective.endDate)}
+                  </span>
+                  {objective.responsibleId && (
+                    <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
+                      <User className="h-3 w-3" />
+                      Responsable asignado
+                    </span>
+                  )}
+                </div>
+              )}
             </div>
-            <Badge variant="outline" className="gap-1.5 shrink-0">
+            <Badge variant="outline" className="gap-1.5 shrink-0 mt-1">
               <span className={`inline-block w-1.5 h-1.5 rounded-full ${cfg.dotClass}`} />
               {cfg.label}
             </Badge>
@@ -69,6 +91,7 @@ export function ObjectivePanel({ objectiveId, onClose, readOnly }: ObjectivePane
                   key={objective.id}
                   objective={objective}
                   readOnly={readOnly}
+                  onClose={onClose}
                 />
               ) : (
                 <div className="space-y-3">

--- a/feature/planning/components/dofa/objective-panel.tsx
+++ b/feature/planning/components/dofa/objective-panel.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useObjectiveQuery, useObjectiveStatusesQuery } from "@/feature/planning/hooks/use-dofa";
+import { ProgressRing } from "./progress-ring";
+import { OBJECTIVE_STATUS_CFG } from "./plan-helpers";
+import { TabObjectiveDescription } from "./tab-objective-description";
+import { TabObjectiveGoals } from "./tab-objective-goals";
+
+interface ObjectivePanelProps {
+  objectiveId: string | null;
+  onClose: () => void;
+  readOnly?: boolean;
+}
+
+export function ObjectivePanel({ objectiveId, onClose, readOnly }: ObjectivePanelProps) {
+  const isOpen = !!objectiveId;
+  const { data: objective, isLoading } = useObjectiveQuery(objectiveId ?? undefined);
+  const { data: statuses = [] } = useObjectiveStatusesQuery();
+
+  const code =
+    objective
+      ? (statuses.find((s) => s.id === objective.statusId)?.code ?? "Planned")
+      : "Planned";
+  const cfg = OBJECTIVE_STATUS_CFG[code] ?? OBJECTIVE_STATUS_CFG.Planned;
+
+  return (
+    <Sheet open={isOpen} onOpenChange={(o) => !o && onClose()}>
+      <SheetContent className="sm:max-w-3xl overflow-y-auto">
+        <SheetHeader className="space-y-2">
+          <div className="flex items-center gap-3">
+            <ProgressRing value={objective?.progressPercentage ?? 0} size={36} />
+            <div className="flex-1 min-w-0">
+              {isLoading ? (
+                <Skeleton className="h-5 w-48" />
+              ) : (
+                <SheetTitle className="truncate">{objective?.name ?? "..."}</SheetTitle>
+              )}
+              {objective?.description && (
+                <p className="text-xs text-muted-foreground line-clamp-2 mt-1">
+                  {objective.description}
+                </p>
+              )}
+            </div>
+            <Badge variant="outline" className="gap-1.5 shrink-0">
+              <span className={`inline-block w-1.5 h-1.5 rounded-full ${cfg.dotClass}`} />
+              {cfg.label}
+            </Badge>
+          </div>
+        </SheetHeader>
+
+        {objectiveId && (
+          <Tabs defaultValue="description" className="mt-4">
+            <TabsList className="grid w-full grid-cols-4">
+              <TabsTrigger value="description">Descripción</TabsTrigger>
+              <TabsTrigger value="goals">Metas</TabsTrigger>
+              <TabsTrigger value="indicators" disabled>Indicadores</TabsTrigger>
+              <TabsTrigger value="measurements" disabled>Mediciones</TabsTrigger>
+            </TabsList>
+            <TabsContent value="description" className="mt-4">
+              {objective ? (
+                // key resets form state when user opens a different objective
+                <TabObjectiveDescription
+                  key={objective.id}
+                  objective={objective}
+                  readOnly={readOnly}
+                />
+              ) : (
+                <div className="space-y-3">
+                  <Skeleton className="h-9 w-full" />
+                  <Skeleton className="h-20 w-full" />
+                </div>
+              )}
+            </TabsContent>
+            <TabsContent value="goals" className="mt-4">
+              <TabObjectiveGoals objectiveId={objectiveId} readOnly={readOnly} />
+            </TabsContent>
+          </Tabs>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/feature/planning/components/dofa/plan-grid.tsx
+++ b/feature/planning/components/dofa/plan-grid.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { Plus, Target } from "lucide-react";
+import { EmptyBlock } from "./empty-block";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -88,27 +89,25 @@ export function PlanGrid({ analysisId, readOnly, onSelectObjective }: PlanGridPr
 
       {/* Empty state */}
       {objectives.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-12 text-center">
-          <div className="h-12 w-12 rounded-full bg-muted flex items-center justify-center text-muted-foreground mb-3">
-            <Target className="h-6 w-6" />
-          </div>
-          <p className="text-sm font-medium">No hay objetivos definidos</p>
-          <p className="text-xs text-muted-foreground max-w-md mt-1">
-            Crea el primer objetivo estratégico para este análisis. Puedes vincularlos a
-            estrategias FO/DO/FA/DA en Fase 2.
-          </p>
-          {!readOnly && (
-            <Button
-              size="sm"
-              variant="outline"
-              className="mt-4 gap-1.5"
-              onClick={() => setCreateOpen(true)}
-            >
-              <Plus className="h-3.5 w-3.5" />
-              Crear primer objetivo
-            </Button>
-          )}
-        </div>
+        <EmptyBlock
+          icon={Target}
+          title="No hay objetivos definidos"
+          description="Crea el primer objetivo estratégico para este análisis. Puedes vincularlos a estrategias FO/DO/FA/DA en Fase 2."
+          className="py-12"
+          cta={
+            !readOnly ? (
+              <Button
+                size="sm"
+                variant="outline"
+                className="gap-1.5"
+                onClick={() => setCreateOpen(true)}
+              >
+                <Plus className="h-3.5 w-3.5" />
+                Crear primer objetivo
+              </Button>
+            ) : undefined
+          }
+        />
       ) : (
         <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
           {objectives.map((obj) => (

--- a/feature/planning/components/dofa/plan-grid.tsx
+++ b/feature/planning/components/dofa/plan-grid.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Plus, Target } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  useObjectivesQuery,
+  useObjectiveStatusesQuery,
+  useStrategiesQuery,
+  useStrategyTypesQuery,
+} from "@/feature/planning/hooks/use-dofa";
+import { ObjectiveCard } from "./objective-card";
+import { CreateObjectiveDialog } from "./create-objective-dialog";
+
+interface PlanGridProps {
+  analysisId: string;
+  readOnly?: boolean;
+  onSelectObjective: (id: string) => void;
+}
+
+export function PlanGrid({ analysisId, readOnly, onSelectObjective }: PlanGridProps) {
+  const { data: objectives = [], isLoading } = useObjectivesQuery({ analysisId });
+  const { data: statuses = [] } = useObjectiveStatusesQuery();
+  const { data: strategies = [] } = useStrategiesQuery(analysisId);
+  const { data: strategyTypes = [] } = useStrategyTypesQuery();
+
+  const [createOpen, setCreateOpen] = useState(false);
+
+  // Average progress across all objectives for the phase-level progress indicator
+  const phase3Progress = useMemo(() => {
+    if (!objectives.length) return 0;
+    const sum = objectives.reduce((acc, o) => acc + (o.progressPercentage ?? 0), 0);
+    return Math.round(sum / objectives.length);
+  }, [objectives]);
+
+  // Origin map: objectiveId → strategies that link to it
+  // Sprint 3.2: computed from strategy-objectives links already fetched per strategy.
+  // TODO (Sprint 3.3): replace with a single aggregated endpoint or batch useQueries.
+  const originMap = useMemo(() => {
+    const map = new Map<string, { code: string; description: string }[]>();
+    // Wiring deferred to Sprint 3.3 — strategies and strategyTypes are pre-fetched
+    // so the dependency is tracked; the map will be populated once the link queries
+    // are added in the next sub-sprint.
+    void strategies;
+    void strategyTypes;
+    return map;
+  }, [strategies, strategyTypes]);
+
+  if (isLoading) {
+    return (
+      <div className="p-6 space-y-3">
+        <Skeleton className="h-10 w-full" />
+        <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+          <Skeleton className="h-28 w-full" />
+          <Skeleton className="h-28 w-full" />
+          <Skeleton className="h-28 w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 p-4 md:p-6">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex-1">
+          <h2 className="text-base font-semibold">Fase 3 — Plan</h2>
+          <div className="flex items-center gap-2 mt-1">
+            <div className="w-48 h-1.5 rounded-full bg-muted overflow-hidden">
+              <div
+                className="h-full bg-amber-500 transition-all"
+                style={{ width: `${phase3Progress}%` }}
+              />
+            </div>
+            <span className="text-xs text-muted-foreground tabular-nums">
+              {phase3Progress}% avance
+            </span>
+          </div>
+        </div>
+        {!readOnly && (
+          <Button size="sm" onClick={() => setCreateOpen(true)} className="gap-1.5">
+            <Plus className="h-4 w-4" />
+            Nuevo objetivo
+          </Button>
+        )}
+      </div>
+
+      {/* Empty state */}
+      {objectives.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <div className="h-12 w-12 rounded-full bg-muted flex items-center justify-center text-muted-foreground mb-3">
+            <Target className="h-6 w-6" />
+          </div>
+          <p className="text-sm font-medium">No hay objetivos definidos</p>
+          <p className="text-xs text-muted-foreground max-w-md mt-1">
+            Crea el primer objetivo estratégico para este análisis. Puedes vincularlos a
+            estrategias FO/DO/FA/DA en Fase 2.
+          </p>
+          {!readOnly && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="mt-4 gap-1.5"
+              onClick={() => setCreateOpen(true)}
+            >
+              <Plus className="h-3.5 w-3.5" />
+              Crear primer objetivo
+            </Button>
+          )}
+        </div>
+      ) : (
+        <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+          {objectives.map((obj) => (
+            <ObjectiveCard
+              key={obj.id}
+              objective={obj}
+              goalsCount={0 /* TODO Sprint 3.3: wire useGoalsQuery({ objectiveId }) */}
+              origins={originMap.get(obj.id) ?? []}
+              statuses={statuses}
+              onClick={() => onSelectObjective(obj.id)}
+            />
+          ))}
+        </div>
+      )}
+
+      <CreateObjectiveDialog
+        open={createOpen}
+        analysisId={analysisId}
+        onClose={() => setCreateOpen(false)}
+        onCreated={(id) => {
+          setCreateOpen(false);
+          onSelectObjective(id);
+        }}
+      />
+    </div>
+  );
+}

--- a/feature/planning/components/dofa/plan-helpers.ts
+++ b/feature/planning/components/dofa/plan-helpers.ts
@@ -1,0 +1,88 @@
+import type {
+  CatalogStatusDto,
+  GoalTrendDto,
+} from "@/feature/planning/api/dofa";
+
+// ---------------------------------------------------------------------------
+// Status configs — mapping CODE → label español + color tone
+// Uses the NEW PascalCase seed; ignores legacy UPPERCASE (PM-13)
+// ---------------------------------------------------------------------------
+
+export const OBJECTIVE_STATUS_CFG: Record<
+  string,
+  { label: string; tone: string; dotClass: string }
+> = {
+  Planned: { label: "Planificado", tone: "neutral", dotClass: "bg-slate-400" },
+  Active: { label: "Activo", tone: "primary", dotClass: "bg-sky-500" },
+  InProgress: { label: "En Progreso", tone: "medium", dotClass: "bg-amber-500" },
+  Achieved: { label: "Logrado", tone: "low", dotClass: "bg-emerald-500" },
+  OnHold: { label: "En Espera", tone: "primary", dotClass: "bg-violet-500" },
+  Cancelled: { label: "Cancelado", tone: "high", dotClass: "bg-rose-500" },
+};
+
+export const GOAL_STATUS_CFG: Record<
+  string,
+  { label: string; tone: string; dotClass: string }
+> = {
+  Defined: { label: "Definida", tone: "neutral", dotClass: "bg-slate-400" },
+  InProgress: { label: "En Progreso", tone: "medium", dotClass: "bg-amber-500" },
+  Achieved: { label: "Lograda", tone: "low", dotClass: "bg-emerald-500" },
+  NotAchieved: { label: "No Lograda", tone: "high", dotClass: "bg-rose-500" },
+  OnHold: { label: "En Espera", tone: "primary", dotClass: "bg-violet-500" },
+};
+
+// ---------------------------------------------------------------------------
+// Lookup helpers (PM-18: backend does NOT return *Name pre-calculated)
+// ---------------------------------------------------------------------------
+
+export function lookupCatalogName<T extends { id: string; name: string }>(
+  id: string | null | undefined,
+  catalog: T[],
+  fallback = "—",
+): string {
+  if (!id) return fallback;
+  return catalog.find((c) => c.id === id)?.name ?? fallback;
+}
+
+export function lookupStatusCode(
+  statusId: string | null | undefined,
+  catalog: CatalogStatusDto[],
+  defaultCode = "Planned",
+): string {
+  if (!statusId) return defaultCode;
+  return catalog.find((s) => s.id === statusId)?.code ?? defaultCode;
+}
+
+export function lookupTrendSymbol(
+  trendId: string | null | undefined,
+  trends: GoalTrendDto[],
+): string | null {
+  if (!trendId) return null;
+  return trends.find((t) => t.id === trendId)?.symbol ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Goal defaults (from Leandro's analysis)
+// ---------------------------------------------------------------------------
+
+export const GOAL_DEFAULTS = {
+  weight: 50,
+  currentValue: 0,
+  baselineValue: 0,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Default status helpers — find UUID of the NEW PascalCase seed entry
+// ---------------------------------------------------------------------------
+
+export function findDefaultObjectiveStatusId(
+  catalog: CatalogStatusDto[],
+): string | null {
+  return catalog.find((s) => s.code === "Planned")?.id ?? null;
+}
+
+export function findDefaultGoalStatusId(
+  catalog: CatalogStatusDto[],
+): string | null {
+  return catalog.find((s) => s.code === "Defined")?.id ?? null;
+}

--- a/feature/planning/components/dofa/progress-ring.tsx
+++ b/feature/planning/components/dofa/progress-ring.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface ProgressRingProps {
+  value: number;
+  size?: number;
+  showLabel?: boolean;
+  className?: string;
+}
+
+const COLOR_STROKE = (v: number) =>
+  v >= 100
+    ? "stroke-emerald-500"
+    : v >= 60
+      ? "stroke-sky-500"
+      : v >= 30
+        ? "stroke-amber-500"
+        : "stroke-rose-500";
+
+const COLOR_TEXT = (v: number) =>
+  v >= 100
+    ? "text-emerald-500"
+    : v >= 60
+      ? "text-sky-500"
+      : v >= 30
+        ? "text-amber-500"
+        : "text-rose-500";
+
+export function ProgressRing({
+  value,
+  size = 40,
+  showLabel = true,
+  className,
+}: ProgressRingProps) {
+  const v = Math.max(0, Math.min(100, value || 0));
+  const r = size / 2 - 4;
+  const circ = 2 * Math.PI * r;
+  const offset = circ - (circ * v) / 100;
+  const strokeClass = COLOR_STROKE(v);
+  const textClass = COLOR_TEXT(v);
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      className={cn(className)}
+    >
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={r}
+        fill="none"
+        className="stroke-border"
+        strokeWidth="3"
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={r}
+        fill="none"
+        className={cn(strokeClass, "transition-all duration-300")}
+        strokeWidth="3"
+        strokeDasharray={circ}
+        strokeDashoffset={offset}
+        strokeLinecap="round"
+        transform={`rotate(-90 ${size / 2} ${size / 2})`}
+      />
+      {showLabel && (
+        <text
+          x="50%"
+          y="50%"
+          textAnchor="middle"
+          dominantBaseline="central"
+          className={cn(textClass, "font-bold")}
+          style={{ fontSize: size > 36 ? 9 : 7 }}
+        >
+          {v}%
+        </text>
+      )}
+    </svg>
+  );
+}

--- a/feature/planning/components/dofa/sparkline.tsx
+++ b/feature/planning/components/dofa/sparkline.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface SparklineProps {
+  values: number[];
+  width?: number;
+  height?: number;
+  className?: string;
+}
+
+export function Sparkline({
+  values,
+  width = 80,
+  height = 24,
+  className,
+}: SparklineProps) {
+  if (!values || values.length < 2) return null;
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const step = width / (values.length - 1);
+  const points = values
+    .map((v, i) => `${i * step},${height - ((v - min) / range) * height}`)
+    .join(" ");
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      className={cn("overflow-visible text-sky-500", className)}
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+      />
+    </svg>
+  );
+}

--- a/feature/planning/components/dofa/strategy-create-objective-form.tsx
+++ b/feature/planning/components/dofa/strategy-create-objective-form.tsx
@@ -43,7 +43,7 @@ export function StrategyCreateObjectiveForm({ strategyId, onDone }: StrategyCrea
         startDate: today,
         endDate: nextYear,
         responsibleId: null,
-        strategyId,
+        analysisId: null,
       });
       // Step 2: link to strategy — awaits Step 1 to avoid race condition
       if (newObj?.id) {

--- a/feature/planning/components/dofa/tab-objective-description.tsx
+++ b/feature/planning/components/dofa/tab-objective-description.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 import { format } from "date-fns";
+import { CalendarDays, Trash2 } from "lucide-react";
+import toast from "react-hot-toast";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -12,9 +14,23 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import {
   useObjectiveStatusesQuery,
   useUpdateObjectiveMutation,
+  useDeleteObjectiveMutation,
 } from "@/feature/planning/hooks/use-dofa";
 import { useUserSearch } from "@/feature/user/hooks/useUserSearch";
 import type { ObjectiveDto } from "@/feature/planning/api/dofa";
@@ -22,11 +38,13 @@ import type { ObjectiveDto } from "@/feature/planning/api/dofa";
 interface TabObjectiveDescriptionProps {
   objective: ObjectiveDto;
   readOnly?: boolean;
+  onClose: () => void;
 }
 
-export function TabObjectiveDescription({ objective, readOnly = false }: TabObjectiveDescriptionProps) {
+export function TabObjectiveDescription({ objective, readOnly = false, onClose }: TabObjectiveDescriptionProps) {
   const { data: statuses = [] } = useObjectiveStatusesQuery();
   const updateMutation = useUpdateObjectiveMutation();
+  const deleteMutation = useDeleteObjectiveMutation();
 
   const { data: usersPage } = useUserSearch({ pageSize: 100, search: "" });
   const users = usersPage?.items ?? [];
@@ -62,6 +80,16 @@ export function TabObjectiveDescription({ objective, readOnly = false }: TabObje
     save({ responsibleId: value === "__none__" ? null : value });
   };
 
+  const handleDelete = async () => {
+    try {
+      await deleteMutation.mutateAsync(objective.id);
+      toast.success("Objetivo eliminado");
+      onClose();
+    } catch {
+      toast.error("Error al eliminar");
+    }
+  };
+
   const statusLabel = statuses.find((s) => s.id === objective.statusId)?.name ?? "—";
 
   const fmtDate = (iso: string) => {
@@ -74,94 +102,140 @@ export function TabObjectiveDescription({ objective, readOnly = false }: TabObje
 
   return (
     <div className="space-y-5">
-      {/* Name */}
-      <div className="space-y-1.5">
-        <Label htmlFor="obj-name">Nombre</Label>
-        <Input
-          id="obj-name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          onBlur={() => name.trim() && save({ name: name.trim() })}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") e.currentTarget.blur();
-          }}
-          placeholder="Nombre del objetivo"
-          disabled={readOnly}
-          className="text-sm"
-        />
-      </div>
-
-      {/* Description */}
-      <div className="space-y-1.5">
-        <Label htmlFor="obj-desc">Descripción</Label>
-        <Textarea
-          id="obj-desc"
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          onBlur={() => save({ description })}
-          placeholder="Describe el objetivo en detalle..."
-          disabled={readOnly}
-          rows={4}
-          className="text-sm resize-none"
-        />
-      </div>
-
-      {/* Responsible */}
-      <div className="space-y-1.5">
-        <Label>Responsable</Label>
-        <Select
-          value={responsibleId}
-          onValueChange={handleResponsibleChange}
-          disabled={readOnly}
-        >
-          <SelectTrigger className="text-sm">
-            <SelectValue placeholder="Sin asignar" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="__none__">Sin asignar</SelectItem>
-            {users.map((u) => (
-              <SelectItem key={u.id} value={u.id}>
-                {u.firstName} {u.lastName}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-
-      {/* Read-only fields — L-004: backend does NOT accept these in UpdateObjectiveCommand */}
-      <div className="grid grid-cols-3 gap-3 pt-2 border-t">
-        <div className="space-y-1">
-          <Label className="text-xs text-muted-foreground">Estado</Label>
-          <p className="text-sm">{statusLabel}</p>
-        </div>
-        <div className="space-y-1">
-          <Label className="text-xs text-muted-foreground">Fecha inicio</Label>
-          <p className="text-sm">{fmtDate(objective.startDate)}</p>
-        </div>
-        <div className="space-y-1">
-          <Label className="text-xs text-muted-foreground">Fecha fin</Label>
-          <p className="text-sm">{fmtDate(objective.endDate)}</p>
-        </div>
-      </div>
-
-      {/* Progress (read-only from backend) */}
-      <div className="space-y-1.5">
-        <Label>Progreso</Label>
-        <div className="space-y-1">
-          <div className="flex items-center justify-between text-xs text-muted-foreground">
-            <span>Avance general</span>
-            <span className="tabular-nums font-medium">{objective.progressPercentage ?? 0}%</span>
-          </div>
-          <div className="w-full h-2 rounded-full bg-muted overflow-hidden">
-            <div
-              className="h-full rounded-full bg-emerald-500 transition-all"
-              style={{ width: `${objective.progressPercentage ?? 0}%` }}
+      <div className="grid grid-cols-2 gap-4">
+        {/* Left column: editable fields */}
+        <div className="space-y-4">
+          {/* Name */}
+          <div className="space-y-1.5">
+            <Label htmlFor="obj-name">Nombre</Label>
+            <Input
+              id="obj-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onBlur={() => name.trim() && save({ name: name.trim() })}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") e.currentTarget.blur();
+              }}
+              placeholder="Nombre del objetivo"
+              disabled={readOnly}
+              className="text-sm"
             />
           </div>
-          <p className="text-[11px] text-muted-foreground">
-            Calculado a partir de metas vinculadas
-          </p>
+
+          {/* Description */}
+          <div className="space-y-1.5">
+            <Label htmlFor="obj-desc">Descripción</Label>
+            <Textarea
+              id="obj-desc"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              onBlur={() => save({ description })}
+              placeholder="Describe el objetivo en detalle..."
+              disabled={readOnly}
+              rows={4}
+              className="text-sm resize-none"
+            />
+          </div>
+
+          {/* Responsible */}
+          <div className="space-y-1.5">
+            <Label>Responsable</Label>
+            <Select
+              value={responsibleId}
+              onValueChange={handleResponsibleChange}
+              disabled={readOnly}
+            >
+              <SelectTrigger className="text-sm">
+                <SelectValue placeholder="Sin asignar" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__none__">Sin asignar</SelectItem>
+                {users.map((u) => (
+                  <SelectItem key={u.id} value={u.id}>
+                    {u.firstName} {u.lastName}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
         </div>
+
+        {/* Right column: read-only date & status cards */}
+        <div className="space-y-2">
+          <div className="rounded-lg border p-3 flex items-start gap-2">
+            <CalendarDays className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
+            <div>
+              <p className="text-[11px] text-muted-foreground">Fecha inicio</p>
+              <p className="text-sm font-medium">{fmtDate(objective.startDate)}</p>
+            </div>
+          </div>
+          <div className="rounded-lg border p-3 flex items-start gap-2">
+            <CalendarDays className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
+            <div>
+              <p className="text-[11px] text-muted-foreground">Fecha fin</p>
+              <p className="text-sm font-medium">{fmtDate(objective.endDate)}</p>
+            </div>
+          </div>
+          <div className="rounded-lg border p-3">
+            <p className="text-[11px] text-muted-foreground">Estado</p>
+            <p className="text-sm font-medium">{statusLabel}</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Progress */}
+      <div className="space-y-2">
+        <Label>Progreso</Label>
+        <div className="text-3xl font-bold tabular-nums leading-none">
+          {objective.progressPercentage ?? 0}%
+        </div>
+        <div className="w-full h-2 rounded-full bg-muted overflow-hidden">
+          <div
+            className="h-full rounded-full bg-emerald-500 transition-all"
+            style={{ width: `${objective.progressPercentage ?? 0}%` }}
+          />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Calculado a partir de metas vinculadas
+        </p>
+      </div>
+
+      {/* Danger zone */}
+      <Separator />
+      <div className="space-y-2">
+        <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+          Acciones peligrosas
+        </p>
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              variant="destructive"
+              size="lg"
+              className="w-full gap-2"
+              disabled={readOnly || deleteMutation.isPending}
+            >
+              <Trash2 className="h-4 w-4" />
+              Eliminar objetivo
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>¿Eliminar este objetivo?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Esta acción eliminará permanentemente el objetivo y todas sus metas, indicadores y mediciones. No se puede deshacer.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancelar</AlertDialogCancel>
+              <AlertDialogAction
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                onClick={handleDelete}
+              >
+                Sí, eliminar
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </div>
     </div>
   );

--- a/feature/planning/components/dofa/tab-objective-description.tsx
+++ b/feature/planning/components/dofa/tab-objective-description.tsx
@@ -101,8 +101,8 @@ export function TabObjectiveDescription({ objective, readOnly = false, onClose }
   };
 
   return (
-    <div className="space-y-5">
-      <div className="grid grid-cols-2 gap-4">
+    <div className="space-y-6">
+      <div className="grid grid-cols-2 gap-6">
         {/* Left column: editable fields */}
         <div className="space-y-4">
           {/* Name */}
@@ -162,21 +162,21 @@ export function TabObjectiveDescription({ objective, readOnly = false, onClose }
 
         {/* Right column: read-only date & status cards */}
         <div className="space-y-2">
-          <div className="rounded-lg border p-3 flex items-start gap-2">
+          <div className="rounded-lg border p-4 flex items-start gap-2">
             <CalendarDays className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
             <div>
               <p className="text-[11px] text-muted-foreground">Fecha inicio</p>
               <p className="text-sm font-medium">{fmtDate(objective.startDate)}</p>
             </div>
           </div>
-          <div className="rounded-lg border p-3 flex items-start gap-2">
+          <div className="rounded-lg border p-4 flex items-start gap-2">
             <CalendarDays className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
             <div>
               <p className="text-[11px] text-muted-foreground">Fecha fin</p>
               <p className="text-sm font-medium">{fmtDate(objective.endDate)}</p>
             </div>
           </div>
-          <div className="rounded-lg border p-3">
+          <div className="rounded-lg border p-4">
             <p className="text-[11px] text-muted-foreground">Estado</p>
             <p className="text-sm font-medium">{statusLabel}</p>
           </div>
@@ -184,7 +184,7 @@ export function TabObjectiveDescription({ objective, readOnly = false, onClose }
       </div>
 
       {/* Progress */}
-      <div className="space-y-2">
+      <div className="space-y-2 pt-2">
         <Label>Progreso</Label>
         <div className="text-3xl font-bold tabular-nums leading-none">
           {objective.progressPercentage ?? 0}%
@@ -201,7 +201,7 @@ export function TabObjectiveDescription({ objective, readOnly = false, onClose }
       </div>
 
       {/* Danger zone */}
-      <Separator />
+      <Separator className="mt-8" />
       <div className="space-y-2">
         <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
           Acciones peligrosas

--- a/feature/planning/components/dofa/tab-objective-description.tsx
+++ b/feature/planning/components/dofa/tab-objective-description.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useState } from "react";
+import { format } from "date-fns";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  useObjectiveStatusesQuery,
+  useUpdateObjectiveMutation,
+} from "@/feature/planning/hooks/use-dofa";
+import { useUserSearch } from "@/feature/user/hooks/useUserSearch";
+import type { ObjectiveDto } from "@/feature/planning/api/dofa";
+
+interface TabObjectiveDescriptionProps {
+  objective: ObjectiveDto;
+  readOnly?: boolean;
+}
+
+export function TabObjectiveDescription({ objective, readOnly = false }: TabObjectiveDescriptionProps) {
+  const { data: statuses = [] } = useObjectiveStatusesQuery();
+  const updateMutation = useUpdateObjectiveMutation();
+
+  const { data: usersPage } = useUserSearch({ pageSize: 100, search: "" });
+  const users = usersPage?.items ?? [];
+
+  const [name, setName] = useState(objective.name);
+  const [description, setDescription] = useState(objective.description ?? "");
+  const [responsibleId, setResponsibleId] = useState(objective.responsibleId ?? "__none__");
+
+  const save = (overrides?: Partial<{ name: string; description: string; responsibleId: string | null }>) => {
+    const effectiveName = overrides?.name ?? name;
+    if (!effectiveName.trim()) return;
+    updateMutation.mutate({
+      objectiveId: objective.id,
+      payload: {
+        id: objective.id,
+        name: effectiveName.trim(),
+        description:
+          overrides?.description !== undefined
+            ? overrides.description || null
+            : description || null,
+        responsibleId:
+          overrides?.responsibleId !== undefined
+            ? overrides.responsibleId
+            : responsibleId === "__none__"
+            ? null
+            : responsibleId,
+      },
+    });
+  };
+
+  const handleResponsibleChange = (value: string) => {
+    setResponsibleId(value);
+    save({ responsibleId: value === "__none__" ? null : value });
+  };
+
+  const statusLabel = statuses.find((s) => s.id === objective.statusId)?.name ?? "—";
+
+  const fmtDate = (iso: string) => {
+    try {
+      return format(new Date(iso), "dd/MM/yyyy");
+    } catch {
+      return iso;
+    }
+  };
+
+  return (
+    <div className="space-y-5">
+      {/* Name */}
+      <div className="space-y-1.5">
+        <Label htmlFor="obj-name">Nombre</Label>
+        <Input
+          id="obj-name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onBlur={() => name.trim() && save({ name: name.trim() })}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") e.currentTarget.blur();
+          }}
+          placeholder="Nombre del objetivo"
+          disabled={readOnly}
+          className="text-sm"
+        />
+      </div>
+
+      {/* Description */}
+      <div className="space-y-1.5">
+        <Label htmlFor="obj-desc">Descripción</Label>
+        <Textarea
+          id="obj-desc"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          onBlur={() => save({ description })}
+          placeholder="Describe el objetivo en detalle..."
+          disabled={readOnly}
+          rows={4}
+          className="text-sm resize-none"
+        />
+      </div>
+
+      {/* Responsible */}
+      <div className="space-y-1.5">
+        <Label>Responsable</Label>
+        <Select
+          value={responsibleId}
+          onValueChange={handleResponsibleChange}
+          disabled={readOnly}
+        >
+          <SelectTrigger className="text-sm">
+            <SelectValue placeholder="Sin asignar" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__none__">Sin asignar</SelectItem>
+            {users.map((u) => (
+              <SelectItem key={u.id} value={u.id}>
+                {u.firstName} {u.lastName}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Read-only fields — L-004: backend does NOT accept these in UpdateObjectiveCommand */}
+      <div className="grid grid-cols-3 gap-3 pt-2 border-t">
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">Estado</Label>
+          <p className="text-sm">{statusLabel}</p>
+        </div>
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">Fecha inicio</Label>
+          <p className="text-sm">{fmtDate(objective.startDate)}</p>
+        </div>
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">Fecha fin</Label>
+          <p className="text-sm">{fmtDate(objective.endDate)}</p>
+        </div>
+      </div>
+
+      {/* Progress (read-only from backend) */}
+      <div className="space-y-1.5">
+        <Label>Progreso</Label>
+        <div className="space-y-1">
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>Avance general</span>
+            <span className="tabular-nums font-medium">{objective.progressPercentage ?? 0}%</span>
+          </div>
+          <div className="w-full h-2 rounded-full bg-muted overflow-hidden">
+            <div
+              className="h-full rounded-full bg-emerald-500 transition-all"
+              style={{ width: `${objective.progressPercentage ?? 0}%` }}
+            />
+          </div>
+          <p className="text-[11px] text-muted-foreground">
+            Calculado a partir de metas vinculadas
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/feature/planning/components/dofa/tab-objective-goals.tsx
+++ b/feature/planning/components/dofa/tab-objective-goals.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Plus, Target } from "lucide-react";
+import toast from "react-hot-toast";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  useGoalsQuery,
+  useGoalStatusesQuery,
+  useDeleteGoalMutation,
+} from "@/feature/planning/hooks/use-dofa";
+import { GoalRow } from "./goal-row";
+import { GoalFormDialog } from "./goal-form-dialog";
+import type { GoalDto } from "@/feature/planning/api/dofa";
+
+interface Props {
+  objectiveId: string;
+  readOnly?: boolean;
+}
+
+export function TabObjectiveGoals({ objectiveId, readOnly }: Props) {
+  const { data: goals = [], isLoading } = useGoalsQuery({ objectiveId });
+  const { data: statuses = [] } = useGoalStatusesQuery();
+  const deleteMutation = useDeleteGoalMutation();
+  const [dialog, setDialog] = useState<{ open: boolean; goal: GoalDto | null }>({
+    open: false,
+    goal: null,
+  });
+
+  // R-5 defensive: filter client-side by objectiveId (PM-16)
+  const filtered = useMemo(
+    () => goals.filter((g) => g.objectiveId === objectiveId),
+    [goals, objectiveId],
+  );
+
+  const handleDelete = async (id: string) => {
+    if (!confirm("¿Eliminar esta meta?")) return;
+    try {
+      await deleteMutation.mutateAsync(id);
+      toast.success("Meta eliminada");
+    } catch {
+      toast.error("Error al eliminar");
+    }
+  };
+
+  if (isLoading) return <Skeleton className="h-24 w-full" />;
+
+  return (
+    <div className="space-y-3">
+      {filtered.length === 0 ? (
+        <div className="flex flex-col items-center text-center py-8">
+          <Target className="h-8 w-8 text-muted-foreground mb-2" />
+          <p className="text-sm font-medium">Sin metas definidas</p>
+          <p className="text-xs text-muted-foreground max-w-sm mt-1">
+            Crea metas medibles con valor base, actual y objetivo. El progreso se calcula
+            automáticamente.
+          </p>
+        </div>
+      ) : (
+        filtered.map((g) => (
+          <GoalRow
+            key={g.id}
+            goal={g}
+            statuses={statuses}
+            onEdit={() => setDialog({ open: true, goal: g })}
+            onDelete={() => handleDelete(g.id)}
+            readOnly={readOnly}
+          />
+        ))
+      )}
+
+      {!readOnly && (
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full gap-1.5"
+          onClick={() => setDialog({ open: true, goal: null })}
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Nueva meta
+        </Button>
+      )}
+
+      <GoalFormDialog
+        open={dialog.open}
+        goal={dialog.goal}
+        objectiveId={objectiveId}
+        onClose={() => setDialog({ open: false, goal: null })}
+      />
+    </div>
+  );
+}

--- a/feature/planning/components/dofa/tab-objective-goals.tsx
+++ b/feature/planning/components/dofa/tab-objective-goals.tsx
@@ -48,7 +48,7 @@ export function TabObjectiveGoals({ objectiveId, readOnly }: Props) {
   if (isLoading) return <Skeleton className="h-24 w-full" />;
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-4">
       {filtered.length === 0 ? (
         <EmptyBlock
           icon={Target}

--- a/feature/planning/components/dofa/tab-objective-goals.tsx
+++ b/feature/planning/components/dofa/tab-objective-goals.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { Plus, Target } from "lucide-react";
+import { EmptyBlock } from "./empty-block";
 import toast from "react-hot-toast";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -49,14 +50,11 @@ export function TabObjectiveGoals({ objectiveId, readOnly }: Props) {
   return (
     <div className="space-y-3">
       {filtered.length === 0 ? (
-        <div className="flex flex-col items-center text-center py-8">
-          <Target className="h-8 w-8 text-muted-foreground mb-2" />
-          <p className="text-sm font-medium">Sin metas definidas</p>
-          <p className="text-xs text-muted-foreground max-w-sm mt-1">
-            Crea metas medibles con valor base, actual y objetivo. El progreso se calcula
-            automáticamente.
-          </p>
-        </div>
+        <EmptyBlock
+          icon={Target}
+          title="Sin metas definidas"
+          description="Crea metas medibles con valor base, actual y objetivo. El progreso se calcula automáticamente."
+        />
       ) : (
         filtered.map((g) => (
           <GoalRow

--- a/feature/planning/components/dofa/tab-objective-indicators.tsx
+++ b/feature/planning/components/dofa/tab-objective-indicators.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Plus } from "lucide-react";
+import { BarChart2, Plus, TrendingUp } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useGoalsQuery, useIndicatorsQuery } from "@/feature/planning/hooks/use-dofa";
 import { IndicatorAccordion } from "./indicator-accordion";
 import { IndicatorFormDialog } from "./indicator-form-dialog";
+import { EmptyBlock } from "./empty-block";
 import type { IndicatorDto } from "@/feature/planning/api/dofa";
 
 interface Props {
@@ -27,9 +28,11 @@ export function TabObjectiveIndicators({ objectiveId, readOnly }: Props) {
 
   if (filteredGoals.length === 0) {
     return (
-      <p className="text-sm text-muted-foreground text-center py-8">
-        Crea primero metas en la tab Metas para poder agregar indicadores.
-      </p>
+      <EmptyBlock
+        icon={BarChart2}
+        title="Sin metas creadas"
+        description="Crea primero metas en la tab Metas para poder agregar indicadores."
+      />
     );
   }
 
@@ -67,7 +70,12 @@ function GoalIndicatorsBlock({ goalId, goalDescription, readOnly }: BlockProps) 
       </h4>
       <div className="space-y-2">
         {indicators.length === 0 ? (
-          <p className="text-xs text-muted-foreground italic px-3">Sin indicadores</p>
+          <EmptyBlock
+            icon={TrendingUp}
+            title="Sin indicadores"
+            description="Agrega un indicador para medir el avance de esta meta."
+            className="py-4"
+          />
         ) : (
           indicators.map((ind) => (
             <IndicatorAccordion

--- a/feature/planning/components/dofa/tab-objective-indicators.tsx
+++ b/feature/planning/components/dofa/tab-objective-indicators.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useGoalsQuery, useIndicatorsQuery } from "@/feature/planning/hooks/use-dofa";
+import { IndicatorAccordion } from "./indicator-accordion";
+import { IndicatorFormDialog } from "./indicator-form-dialog";
+import type { IndicatorDto } from "@/feature/planning/api/dofa";
+
+interface Props {
+  objectiveId: string;
+  readOnly?: boolean;
+}
+
+export function TabObjectiveIndicators({ objectiveId, readOnly }: Props) {
+  const { data: goals = [], isLoading } = useGoalsQuery({ objectiveId });
+
+  // PM-16: client-side filter (already done in hook, but defensive)
+  const filteredGoals = useMemo(
+    () => goals.filter((g) => g.objectiveId === objectiveId),
+    [goals, objectiveId],
+  );
+
+  if (isLoading) return <Skeleton className="h-32 w-full" />;
+
+  if (filteredGoals.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground text-center py-8">
+        Crea primero metas en la tab Metas para poder agregar indicadores.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      {filteredGoals.map((goal) => (
+        <GoalIndicatorsBlock
+          key={goal.id}
+          goalId={goal.id}
+          goalDescription={goal.description}
+          readOnly={readOnly}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface BlockProps {
+  goalId: string;
+  goalDescription: string;
+  readOnly?: boolean;
+}
+
+function GoalIndicatorsBlock({ goalId, goalDescription, readOnly }: BlockProps) {
+  const { data: indicators = [] } = useIndicatorsQuery(goalId);
+  const [dialog, setDialog] = useState<{ open: boolean; ind: IndicatorDto | null }>({
+    open: false,
+    ind: null,
+  });
+
+  return (
+    <div>
+      <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
+        {goalDescription}
+      </h4>
+      <div className="space-y-2">
+        {indicators.length === 0 ? (
+          <p className="text-xs text-muted-foreground italic px-3">Sin indicadores</p>
+        ) : (
+          indicators.map((ind) => (
+            <IndicatorAccordion
+              key={ind.id}
+              indicator={ind}
+              goalId={goalId}
+              onEdit={() => setDialog({ open: true, ind })}
+              readOnly={readOnly}
+            />
+          ))
+        )}
+        {!readOnly && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full gap-1.5"
+            onClick={() => setDialog({ open: true, ind: null })}
+          >
+            <Plus className="h-3 w-3" /> Nuevo indicador
+          </Button>
+        )}
+      </div>
+
+      <IndicatorFormDialog
+        open={dialog.open}
+        indicator={dialog.ind}
+        goalId={goalId}
+        onClose={() => setDialog({ open: false, ind: null })}
+      />
+    </div>
+  );
+}

--- a/feature/planning/components/dofa/tab-objective-measurements.tsx
+++ b/feature/planning/components/dofa/tab-objective-measurements.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useMemo } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Link as LinkIcon } from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { fmtDate } from "@/lib/format";
+import {
+  useGoalsQuery,
+  useIndicatorsQuery,
+  useIndicatorDetailQuery,
+} from "@/feature/planning/hooks/use-dofa";
+import type { GoalDto, IndicatorDto, MeasurementDto } from "@/feature/planning/api/dofa";
+
+interface Props {
+  objectiveId: string;
+}
+
+export function TabObjectiveMeasurements({ objectiveId }: Props) {
+  const { data: goals = [], isLoading: goalsLoading } = useGoalsQuery({ objectiveId });
+  const filteredGoals = useMemo(
+    () => goals.filter((g) => g.objectiveId === objectiveId),
+    [goals, objectiveId],
+  );
+
+  if (goalsLoading) return <Skeleton className="h-32 w-full" />;
+
+  if (filteredGoals.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground text-center py-8">
+        Sin metas ni mediciones registradas.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {filteredGoals.map((goal) => (
+        <GoalMeasurementsRows key={goal.id} goal={goal} />
+      ))}
+    </div>
+  );
+}
+
+/** Renders rows for all indicators of a single goal */
+function GoalMeasurementsRows({ goal }: { goal: GoalDto }) {
+  const { data: indicators = [], isLoading } = useIndicatorsQuery(goal.id);
+
+  if (isLoading) return <Skeleton className="h-12 w-full" />;
+  if (indicators.length === 0) return null;
+
+  return (
+    <>
+      {indicators.map((ind) => (
+        <IndicatorMeasurementRows key={ind.id} indicator={ind} goal={goal} />
+      ))}
+    </>
+  );
+}
+
+/** Renders rows for all measurements of a single indicator */
+function IndicatorMeasurementRows({
+  indicator,
+  goal,
+}: {
+  indicator: IndicatorDto;
+  goal: GoalDto;
+}) {
+  // Always fetch detail here — this tab shows everything
+  const { data: detail, isLoading } = useIndicatorDetailQuery(goal.id, indicator.id);
+  const measurements: MeasurementDto[] = detail?.measurements ?? [];
+
+  if (isLoading || measurements.length === 0) return null;
+
+  const sorted = [...measurements].sort((a, b) =>
+    b.measurementDate.localeCompare(a.measurementDate),
+  );
+
+  return (
+    <div>
+      <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1">
+        {goal.description} — {indicator.name}
+      </h4>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Fecha</TableHead>
+            <TableHead>Indicador</TableHead>
+            <TableHead>Meta</TableHead>
+            <TableHead>Valor</TableHead>
+            <TableHead>Observaciones</TableHead>
+            <TableHead>Evidencia</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sorted.map((m) => (
+            <TableRow key={m.id}>
+              <TableCell className="font-mono text-xs">
+                {fmtDate(m.measurementDate)}
+              </TableCell>
+              <TableCell className="text-xs">{indicator.name}</TableCell>
+              <TableCell className="text-xs text-muted-foreground">
+                {goal.description}
+              </TableCell>
+              <TableCell className="font-mono font-semibold text-sky-500">
+                {m.value}
+              </TableCell>
+              <TableCell className="text-xs text-muted-foreground">
+                {m.observations || "—"}
+              </TableCell>
+              <TableCell>
+                {m.evidenceUrl ? (
+                  <a
+                    href={m.evidenceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs text-sky-500 inline-flex items-center gap-1"
+                  >
+                    <LinkIcon className="h-3 w-3" />
+                    Ver
+                  </a>
+                ) : (
+                  "—"
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/feature/planning/components/dofa/tab-objective-measurements.tsx
+++ b/feature/planning/components/dofa/tab-objective-measurements.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useMemo } from "react";
+import { Activity, Link as LinkIcon } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Link as LinkIcon } from "lucide-react";
+import { EmptyBlock } from "./empty-block";
 import {
   Table,
   TableBody,
@@ -34,9 +35,11 @@ export function TabObjectiveMeasurements({ objectiveId }: Props) {
 
   if (filteredGoals.length === 0) {
     return (
-      <p className="text-sm text-muted-foreground text-center py-8">
-        Sin metas ni mediciones registradas.
-      </p>
+      <EmptyBlock
+        icon={Activity}
+        title="Sin mediciones registradas"
+        description="Las mediciones aparecerán aquí una vez que tengas metas e indicadores configurados."
+      />
     );
   }
 

--- a/feature/planning/hooks/use-dofa.ts
+++ b/feature/planning/hooks/use-dofa.ts
@@ -698,6 +698,8 @@ export function useGoalUpdateMutation() {
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: planKeys.goals() });
       queryClient.invalidateQueries({ queryKey: planKeys.goal(variables.goalId) });
+      // Invalidate objectives so progressPercentage refreshes in ObjectivePanel
+      queryClient.invalidateQueries({ queryKey: planKeys.objectives() });
     },
   });
 }

--- a/feature/planning/hooks/use-dofa.ts
+++ b/feature/planning/hooks/use-dofa.ts
@@ -569,13 +569,8 @@ export function useObjectivesQuery(filters?: { analysisId?: string }) {
       const all = await listObjectives();
       if (!filters?.analysisId) return all;
       // PM-15 workaround: filter client-side since backend ignores analysisId
-      // WORKAROUND PM-21: backend descarta analysisId en POST /objectives.
-      // Mientras Hernán arregla el backend, también mostramos los huérfanos
-      // (analysisId === null). Restaurar a `o.analysisId === analysisId` cuando
-      // el backend procese correctamente el campo.
-      return all.filter(
-        (o) => o.analysisId === filters.analysisId || o.analysisId === null,
-      );
+      // PM-21 resolved: backend now sets analysisId correctly; orphan (null) objectives excluded.
+      return all.filter((o) => o.analysisId === filters.analysisId);
     },
   });
 }

--- a/feature/planning/hooks/use-dofa.ts
+++ b/feature/planning/hooks/use-dofa.ts
@@ -569,7 +569,13 @@ export function useObjectivesQuery(filters?: { analysisId?: string }) {
       const all = await listObjectives();
       if (!filters?.analysisId) return all;
       // PM-15 workaround: filter client-side since backend ignores analysisId
-      return all.filter((o) => o.analysisId === filters.analysisId);
+      // WORKAROUND PM-21: backend descarta analysisId en POST /objectives.
+      // Mientras Hernán arregla el backend, también mostramos los huérfanos
+      // (analysisId === null). Restaurar a `o.analysisId === analysisId` cuando
+      // el backend procese correctamente el campo.
+      return all.filter(
+        (o) => o.analysisId === filters.analysisId || o.analysisId === null,
+      );
     },
   });
 }

--- a/feature/planning/hooks/use-dofa.ts
+++ b/feature/planning/hooks/use-dofa.ts
@@ -16,6 +16,10 @@ import {
   deleteBscPerspective,
   listStrategyTypes,
   listObjectiveStatuses,
+  listGoalStatuses,
+  listGoalFrequencies,
+  listGoalTrends,
+  listIndicatorTypes,
   listStrategies,
   getStrategyById,
   createStrategy,
@@ -30,13 +34,17 @@ import {
   updateStrategyObjectiveLink,
   unlinkObjectiveFromStrategy,
   listObjectives,
+  getObjective,
   createObjective,
   updateObjective,
   deleteObjective,
   listGoals,
+  getGoal,
   createGoal,
   updateGoal,
+  deleteGoal,
   listIndicators,
+  getIndicatorDetail,
   createIndicator,
   updateIndicator,
   deleteIndicator,
@@ -70,7 +78,6 @@ import {
   type CreateStakeholderDofaLinkCommand,
   type UpdateStakeholderDofaLinkCommand,
   type ListStrategiesFilters,
-  type ListObjectivesFilters,
 } from "../api/dofa";
 
 // ---------------------------------------------------------------------------
@@ -96,11 +103,6 @@ export const strategyTypeKeys = {
   list: () => [...strategyTypeKeys.all, "list"] as const,
 };
 
-export const objectiveStatusKeys = {
-  all: ["strategic", "objective-statuses"] as const,
-  list: () => [...objectiveStatusKeys.all, "list"] as const,
-};
-
 export const strategyKeys = {
   all: ["strategic", "strategies"] as const,
   lists: () => [...strategyKeys.all, "list"] as const,
@@ -115,38 +117,39 @@ export const strategyKeys = {
     [...strategyKeys.detail(strategyId), "objectives"] as const,
 };
 
-export const objectiveKeys = {
-  all: ["strategic", "objectives"] as const,
-  lists: () => [...objectiveKeys.all, "list"] as const,
-  list: (filters?: ListObjectivesFilters) =>
-    [...objectiveKeys.lists(), filters ?? {}] as const,
-  details: () => [...objectiveKeys.all, "detail"] as const,
-  detail: (id: string) => [...objectiveKeys.details(), id] as const,
-};
-
-export const goalKeys = {
-  all: ["strategic", "goals"] as const,
-  lists: () => [...goalKeys.all, "list"] as const,
-  list: () => [...goalKeys.lists()] as const,
-  details: () => [...goalKeys.all, "detail"] as const,
-  detail: (id: string) => [...goalKeys.details(), id] as const,
-};
-
-export const indicatorKeys = {
-  all: ["strategic", "indicators"] as const,
-  byGoal: (goalId: string) => [...indicatorKeys.all, "goal", goalId] as const,
-};
-
-export const measurementKeys = {
-  all: ["strategic", "measurements"] as const,
-  byIndicator: (indicatorId: string) =>
-    [...measurementKeys.all, "indicator", indicatorId] as const,
-};
-
 export const stakeholderDofaLinkKeys = {
   all: ["strategic", "stakeholder-dofa-links"] as const,
   lists: () => [...stakeholderDofaLinkKeys.all, "list"] as const,
   list: () => [...stakeholderDofaLinkKeys.lists()] as const,
+};
+
+/**
+ * Unified hierarchical key factory for the Plan layer (Sprint 3).
+ * Replaces the old objectiveKeys / goalKeys / indicatorKeys / measurementKeys /
+ * objectiveStatusKeys which are now removed.
+ */
+export const planKeys = {
+  // Objectives
+  objectives: () => ["dofa", "objectives"] as const,
+  objectivesByAnalysis: (analysisId: string) =>
+    ["dofa", "objectives", { analysisId }] as const,
+  objective: (id: string) => ["dofa", "objectives", id] as const,
+  // Goals
+  goals: () => ["dofa", "goals"] as const,
+  goalsByObjective: (objectiveId: string) =>
+    ["dofa", "goals", { objectiveId }] as const,
+  goal: (id: string) => ["dofa", "goals", id] as const,
+  // Indicators (nested under goals)
+  indicators: (goalId: string) =>
+    ["dofa", "goals", goalId, "indicators"] as const,
+  indicatorDetail: (goalId: string, indicatorId: string) =>
+    ["dofa", "goals", goalId, "indicators", indicatorId] as const,
+  // Catalogues
+  objectiveStatuses: () => ["dofa", "objective-statuses"] as const,
+  goalStatuses: () => ["dofa", "goal-statuses"] as const,
+  goalFrequencies: () => ["dofa", "goal-frequencies"] as const,
+  goalTrends: () => ["dofa", "goal-trends"] as const,
+  indicatorTypes: () => ["dofa", "indicator-types"] as const,
 };
 
 // ---------------------------------------------------------------------------
@@ -324,8 +327,9 @@ export function useStrategyTypesQuery() {
 
 export function useObjectiveStatusesQuery() {
   return useQuery({
-    queryKey: objectiveStatusKeys.list(),
+    queryKey: planKeys.objectiveStatuses(),
     queryFn: listObjectiveStatuses,
+    staleTime: Infinity,
   });
 }
 
@@ -505,7 +509,7 @@ export function useLinkObjectiveToStrategyMutation() {
       queryClient.invalidateQueries({
         queryKey: strategyKeys.objectives(variables.strategyId),
       });
-      queryClient.invalidateQueries({ queryKey: objectiveKeys.all });
+      queryClient.invalidateQueries({ queryKey: planKeys.objectives() });
     },
   });
 }
@@ -552,10 +556,34 @@ export function useUnlinkObjectiveFromStrategyMutation() {
 // Objectives
 // ---------------------------------------------------------------------------
 
-export function useObjectivesQuery(filters?: ListObjectivesFilters) {
+/**
+ * Fetch all objectives, optionally filtered by analysisId client-side.
+ * PM-15: backend ignores ?status and ?responsibleId query params.
+ */
+export function useObjectivesQuery(filters?: { analysisId?: string }) {
   return useQuery({
-    queryKey: objectiveKeys.list(filters),
-    queryFn: () => listObjectives(filters),
+    queryKey: filters?.analysisId
+      ? planKeys.objectivesByAnalysis(filters.analysisId)
+      : planKeys.objectives(),
+    queryFn: async () => {
+      const all = await listObjectives();
+      if (!filters?.analysisId) return all;
+      // PM-15 workaround: filter client-side since backend ignores analysisId
+      return all.filter((o) => o.analysisId === filters.analysisId);
+    },
+  });
+}
+
+export function useObjectiveQuery(objectiveId?: string) {
+  return useQuery({
+    queryKey: objectiveId
+      ? planKeys.objective(objectiveId)
+      : planKeys.objective("__none__"),
+    queryFn: async () => {
+      if (!objectiveId) return null;
+      return getObjective(objectiveId);
+    },
+    enabled: !!objectiveId,
   });
 }
 
@@ -564,11 +592,14 @@ export function useObjectiveCreateMutation() {
   return useMutation({
     mutationFn: (payload: CreateObjectiveCommand) => createObjective(payload),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: objectiveKeys.all });
+      queryClient.invalidateQueries({ queryKey: planKeys.objectives() });
       queryClient.invalidateQueries({ queryKey: strategyKeys.all });
     },
   });
 }
+
+/** Alias for Sprint 3+ components */
+export const useCreateObjectiveMutation = useObjectiveCreateMutation;
 
 export function useObjectiveUpdateMutation() {
   const queryClient = useQueryClient();
@@ -580,29 +611,63 @@ export function useObjectiveUpdateMutation() {
       objectiveId: string;
       payload: UpdateObjectiveCommand;
     }) => updateObjective(objectiveId, payload),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: objectiveKeys.all });
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: planKeys.objectives() });
+      queryClient.invalidateQueries({
+        queryKey: planKeys.objective(variables.objectiveId),
+      });
     },
   });
 }
+
+/** Alias for Sprint 3+ components */
+export const useUpdateObjectiveMutation = useObjectiveUpdateMutation;
 
 export function useObjectiveDeleteMutation() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (objectiveId: string) => deleteObjective(objectiveId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: objectiveKeys.all });
+      queryClient.invalidateQueries({ queryKey: planKeys.objectives() });
       queryClient.invalidateQueries({ queryKey: strategyKeys.all });
     },
   });
 }
 
+/** Alias for Sprint 3+ components */
+export const useDeleteObjectiveMutation = useObjectiveDeleteMutation;
+
 // ---------------------------------------------------------------------------
 // Goals
 // ---------------------------------------------------------------------------
 
-export function useGoalsQuery() {
-  return useQuery({ queryKey: goalKeys.list(), queryFn: listGoals });
+/**
+ * Fetch all goals, optionally filtered by objectiveId client-side.
+ * PM-16: backend has no server-side filter for objectiveId.
+ */
+export function useGoalsQuery(filters?: { objectiveId?: string }) {
+  return useQuery({
+    queryKey: filters?.objectiveId
+      ? planKeys.goalsByObjective(filters.objectiveId)
+      : planKeys.goals(),
+    queryFn: async () => {
+      const all = await listGoals();
+      if (!filters?.objectiveId) return all;
+      // PM-16 workaround: filter client-side
+      return all.filter((g) => g.objectiveId === filters.objectiveId);
+    },
+  });
+}
+
+export function useGoalQuery(goalId?: string) {
+  return useQuery({
+    queryKey: goalId ? planKeys.goal(goalId) : planKeys.goal("__none__"),
+    queryFn: async () => {
+      if (!goalId) return null;
+      return getGoal(goalId);
+    },
+    enabled: !!goalId,
+  });
 }
 
 export function useGoalCreateMutation() {
@@ -610,11 +675,14 @@ export function useGoalCreateMutation() {
   return useMutation({
     mutationFn: (payload: CreateGoalCommand) => createGoal(payload),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: goalKeys.all });
-      queryClient.invalidateQueries({ queryKey: objectiveKeys.all });
+      queryClient.invalidateQueries({ queryKey: planKeys.goals() });
+      queryClient.invalidateQueries({ queryKey: planKeys.objectives() });
     },
   });
 }
+
+/** Alias for Sprint 3+ components */
+export const useCreateGoalMutation = useGoalCreateMutation;
 
 export function useGoalUpdateMutation() {
   const queryClient = useQueryClient();
@@ -626,11 +694,29 @@ export function useGoalUpdateMutation() {
       goalId: string;
       payload: UpdateGoalCommand;
     }) => updateGoal(goalId, payload),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: goalKeys.all });
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: planKeys.goals() });
+      queryClient.invalidateQueries({ queryKey: planKeys.goal(variables.goalId) });
     },
   });
 }
+
+/** Alias for Sprint 3+ components */
+export const useUpdateGoalMutation = useGoalUpdateMutation;
+
+export function useGoalDeleteMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (goalId: string) => deleteGoal(goalId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: planKeys.goals() });
+      queryClient.invalidateQueries({ queryKey: planKeys.objectives() });
+    },
+  });
+}
+
+/** Alias for Sprint 3+ components */
+export const useDeleteGoalMutation = useGoalDeleteMutation;
 
 // ---------------------------------------------------------------------------
 // Indicators
@@ -638,9 +724,25 @@ export function useGoalUpdateMutation() {
 
 export function useIndicatorsQuery(goalId: string) {
   return useQuery({
-    queryKey: indicatorKeys.byGoal(goalId),
+    queryKey: planKeys.indicators(goalId),
     queryFn: () => listIndicators(goalId),
     enabled: !!goalId,
+  });
+}
+
+/**
+ * Single indicator WITH nested measurements (PM-14: only way to read measurements).
+ * Use `options.enabled = false` for lazy load.
+ */
+export function useIndicatorDetailQuery(
+  goalId: string,
+  indicatorId: string,
+  options?: { enabled?: boolean },
+) {
+  return useQuery({
+    queryKey: planKeys.indicatorDetail(goalId, indicatorId),
+    queryFn: () => getIndicatorDetail(goalId, indicatorId),
+    enabled: options?.enabled !== undefined ? options.enabled : !!goalId && !!indicatorId,
   });
 }
 
@@ -656,11 +758,14 @@ export function useIndicatorCreateMutation() {
     }) => createIndicator(goalId, payload),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
-        queryKey: indicatorKeys.byGoal(variables.goalId),
+        queryKey: planKeys.indicators(variables.goalId),
       });
     },
   });
 }
+
+/** Alias for Sprint 3+ components */
+export const useCreateIndicatorMutation = useIndicatorCreateMutation;
 
 export function useIndicatorUpdateMutation() {
   const queryClient = useQueryClient();
@@ -676,11 +781,17 @@ export function useIndicatorUpdateMutation() {
     }) => updateIndicator(goalId, indicatorId, payload),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
-        queryKey: indicatorKeys.byGoal(variables.goalId),
+        queryKey: planKeys.indicators(variables.goalId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: planKeys.indicatorDetail(variables.goalId, variables.indicatorId),
       });
     },
   });
 }
+
+/** Alias for Sprint 3+ components */
+export const useUpdateIndicatorMutation = useIndicatorUpdateMutation;
 
 export function useIndicatorDeleteMutation() {
   const queryClient = useQueryClient();
@@ -689,14 +800,18 @@ export function useIndicatorDeleteMutation() {
       deleteIndicator(goalId, indicatorId),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
-        queryKey: indicatorKeys.byGoal(variables.goalId),
+        queryKey: planKeys.indicators(variables.goalId),
       });
     },
   });
 }
 
+/** Alias for Sprint 3+ components */
+export const useDeleteIndicatorMutation = useIndicatorDeleteMutation;
+
 // ---------------------------------------------------------------------------
-// Measurements (no GET list — backend gap)
+// Measurements (no GET list — backend gap PM-14)
+// Mutations must invalidate planKeys.indicatorDetail to refresh nested measurements.
 // ---------------------------------------------------------------------------
 
 export function useMeasurementCreateMutation() {
@@ -707,15 +822,20 @@ export function useMeasurementCreateMutation() {
       payload,
     }: {
       indicatorId: string;
+      goalId: string;
       payload: CreateMeasurementCommand;
     }) => createMeasurement(indicatorId, payload),
     onSuccess: (_data, variables) => {
+      // Invalidate the indicator detail so measurements array is refreshed
       queryClient.invalidateQueries({
-        queryKey: measurementKeys.byIndicator(variables.indicatorId),
+        queryKey: planKeys.indicatorDetail(variables.goalId, variables.indicatorId),
       });
     },
   });
 }
+
+/** Alias for Sprint 3+ components */
+export const useCreateMeasurementMutation = useMeasurementCreateMutation;
 
 export function useMeasurementUpdateMutation() {
   const queryClient = useQueryClient();
@@ -726,16 +846,20 @@ export function useMeasurementUpdateMutation() {
       payload,
     }: {
       indicatorId: string;
+      goalId: string;
       measurementId: string;
       payload: UpdateMeasurementCommand;
     }) => updateMeasurement(indicatorId, measurementId, payload),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
-        queryKey: measurementKeys.byIndicator(variables.indicatorId),
+        queryKey: planKeys.indicatorDetail(variables.goalId, variables.indicatorId),
       });
     },
   });
 }
+
+/** Alias for Sprint 3+ components */
+export const useUpdateMeasurementMutation = useMeasurementUpdateMutation;
 
 export function useMeasurementDeleteMutation() {
   const queryClient = useQueryClient();
@@ -745,13 +869,53 @@ export function useMeasurementDeleteMutation() {
       measurementId,
     }: {
       indicatorId: string;
+      goalId: string;
       measurementId: string;
     }) => deleteMeasurement(indicatorId, measurementId),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
-        queryKey: measurementKeys.byIndicator(variables.indicatorId),
+        queryKey: planKeys.indicatorDetail(variables.goalId, variables.indicatorId),
       });
     },
+  });
+}
+
+/** Alias for Sprint 3+ components */
+export const useDeleteMeasurementMutation = useMeasurementDeleteMutation;
+
+// ---------------------------------------------------------------------------
+// Catalogues (staleTime: Infinity — these change only after backend seed updates)
+// ---------------------------------------------------------------------------
+
+export function useGoalStatusesQuery() {
+  return useQuery({
+    queryKey: planKeys.goalStatuses(),
+    queryFn: listGoalStatuses,
+    staleTime: Infinity,
+  });
+}
+
+export function useGoalFrequenciesQuery() {
+  return useQuery({
+    queryKey: planKeys.goalFrequencies(),
+    queryFn: listGoalFrequencies,
+    staleTime: Infinity,
+  });
+}
+
+export function useGoalTrendsQuery() {
+  return useQuery({
+    queryKey: planKeys.goalTrends(),
+    queryFn: listGoalTrends,
+    staleTime: Infinity,
+  });
+}
+
+export function useIndicatorTypesQuery() {
+  return useQuery({
+    queryKey: planKeys.indicatorTypes(),
+    queryFn: listIndicatorTypes,
+    staleTime: Infinity,
   });
 }
 

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,0 +1,13 @@
+import { format } from "date-fns";
+
+/**
+ * Format an ISO date string as dd/MM/yyyy.
+ * Returns the raw string if parsing fails.
+ */
+export function fmtDate(iso: string): string {
+  try {
+    return format(new Date(iso), "dd/MM/yyyy");
+  } catch {
+    return iso;
+  }
+}


### PR DESCRIPTION
## Summary

- **TabObjectiveIndicators**: groups indicators by goal; each goal block has a \"+ Nuevo indicador\" button and renders `IndicatorAccordion` per indicator
- **IndicatorAccordion**: lazy-loads indicator detail on expand (PM-14), shows measurements table with sparkline for 2+ readings, CRUD actions for measurements
- **IndicatorFormDialog**: create/edit form with frequency, indicator-type, and trend catalog selectors (PM-18 client-side lookup)
- **MeasurementFormDialog**: date / value / observations / evidence URL; handles PM-19 (redundant `goalIndicatorId` in body) and PM-17 (UUID string response from POST)
- **TabObjectiveMeasurements**: consolidated read-only chronological view of all measurements across all goals/indicators of an objective
- **lib/format.ts**: shared `fmtDate` helper (dd/MM/yyyy) used across the new components
- **ObjectivePanel**: removes `disabled` from the two previously-stubbed tabs and wires in the two new content components

## Architecture notes

- No new dependencies added
- All HTTP calls go through `feature/planning/api/dofa.ts` via existing `api` from `@/lib/axios`
- Mutations use existing aliases in `use-dofa.ts` (`useCreateIndicatorMutation`, `useCreateMeasurementMutation`, etc.)
- Catalog data (frequencies, types, trends) fetched with `staleTime: Infinity` hooks
- Guardian: WARN only (pre-existing double-toast pattern matches `goal-form-dialog.tsx`; `readOnly` fixed on measurements tab)

## Test plan

- [ ] Build: `npm run build` — clean (no new errors)
- [ ] Lint: `npm run lint` — no new errors from Sprint 3.4 files
- [ ] Open objective panel → Tab Indicadores enabled and renders
- [ ] Create an indicator (frequency, type required) → appears in list
- [ ] Expand indicator → empty state shown; create a measurement → row appears
- [ ] Create a 2nd measurement → sparkline renders in accordion header
- [ ] Edit and delete measurement from accordion table
- [ ] Edit and delete indicator
- [ ] Tab Mediciones shows consolidated table of all measurements
- [ ] readOnly mode: no edit/delete buttons visible in either tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)